### PR TITLE
Add support for multiple palettes

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -19,7 +19,7 @@ export class AppComponent {
 
   public constructor() {
     // Check if user has palette
-    const hasPalette = localStorage.getItem(LocalStorageKey.PALETTE);
+    const hasPalette = localStorage.getItem(LocalStorageKey.PALETTE_IDS);
     if (hasPalette) {
       return;
     }

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -1,6 +1,6 @@
 import { HttpClient, provideHttpClient, withFetch } from '@angular/common/http';
 import { ApplicationConfig, importProvidersFrom, isDevMode } from '@angular/core';
-import { provideRouter, withInMemoryScrolling, withRouterConfig } from '@angular/router';
+import { provideRouter, withComponentInputBinding, withInMemoryScrolling, withRouterConfig } from '@angular/router';
 import { provideServiceWorker } from '@angular/service-worker';
 import { TranslateLoader, TranslateModule } from '@ngx-translate/core';
 import { TranslateHttpLoader } from '@ngx-translate/http-loader';
@@ -18,7 +18,8 @@ export const appConfig: ApplicationConfig = {
       }),
       withRouterConfig({
         onSameUrlNavigation: 'reload'
-      })
+      }),
+      withComponentInputBinding()
     ),
     provideHttpClient(withFetch()),
     importProvidersFrom(

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,4 +1,5 @@
 import { Routes } from '@angular/router';
+import { unsavedChangesGuard } from './view/utils/unsaved-changes.guard';
 
 export const routes: Routes = [
   {
@@ -16,6 +17,7 @@ export const routes: Routes = [
       },
       {
         path: ':id',
+        canDeactivate: [unsavedChangesGuard],
         loadComponent: () => import('./view/view.component')
       }
     ]

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -8,7 +8,17 @@ export const routes: Routes = [
   },
   {
     path: 'view',
-    loadComponent: () => import('./view/view.component')
+    children: [
+      {
+        path: '',
+        pathMatch: 'full',
+        loadComponent: () => import('./list/list.component')
+      },
+      {
+        path: ':id',
+        loadComponent: () => import('./view/view.component')
+      }
+    ]
   },
   {
     path: 'preview',

--- a/src/app/home/home.component.spec.ts
+++ b/src/app/home/home.component.spec.ts
@@ -66,6 +66,6 @@ describe('HomeComponent', () => {
   it('should navigate to view on palette generation', async () => {
     await component.generatePalette();
 
-    expect(router.navigate).toHaveBeenCalledWith(['/view']);
+    expect(router.navigate).toHaveBeenCalledWith(['/view', 'test-id']);
   });
 });

--- a/src/app/home/home.component.spec.ts
+++ b/src/app/home/home.component.spec.ts
@@ -66,6 +66,6 @@ describe('HomeComponent', () => {
   it('should navigate to view on palette generation', async () => {
     await component.generatePalette();
 
-    expect(router.navigate).toHaveBeenCalledWith(['/view', 'test-id']);
+    expect(router.navigate).toHaveBeenCalledWith(['/view', 'test-id'], { info: { palette: 'new' } });
   });
 });

--- a/src/app/home/home.component.spec.ts
+++ b/src/app/home/home.component.spec.ts
@@ -39,26 +39,26 @@ describe('HomeComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should save generation settings on palette generation', () => {
+  it('should save generation settings on palette generation', async () => {
     spyOn(homeService, 'saveGenerationSettings');
 
-    component.generatePalette();
+    await component.generatePalette();
 
     expect(homeService.saveGenerationSettings).toHaveBeenCalled();
   });
 
-  it('should generate palette on palette generation', () => {
+  it('should generate palette on palette generation', async () => {
     spyOn(paletteService, 'generatePalette');
 
-    component.generatePalette();
+    await component.generatePalette();
 
     expect(paletteService.generatePalette).toHaveBeenCalledWith(homeService.hex(), homeService.scheme());
   });
 
-  it('should track palette generation on palette generation', () => {
+  it('should track palette generation on palette generation', async () => {
     spyOn(analyticsService, 'trackPaletteGeneration');
 
-    component.generatePalette();
+    await component.generatePalette();
 
     expect(analyticsService.trackPaletteGeneration).toHaveBeenCalled();
   });

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -28,6 +28,6 @@ export default class HomeComponent {
     const id = await this._paletteService.generatePalette(this.hex(), this.scheme());
     this._analyticsService.trackPaletteGeneration(this.scheme());
 
-    await this._router.navigate(['/view']);
+    await this._router.navigate(['/view', id]);
   }
 }

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -25,7 +25,7 @@ export default class HomeComponent {
   public async generatePalette(): Promise<void> {
     this._homeService.saveGenerationSettings();
 
-    this._paletteService.generatePalette(this.hex(), this.scheme());
+    const id = await this._paletteService.generatePalette(this.hex(), this.scheme());
     this._analyticsService.trackPaletteGeneration(this.scheme());
 
     await this._router.navigate(['/view']);

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -28,6 +28,10 @@ export default class HomeComponent {
     const id = await this._paletteService.generatePalette(this.hex(), this.scheme());
     this._analyticsService.trackPaletteGeneration(this.scheme());
 
-    await this._router.navigate(['/view', id]);
+    await this._router.navigate(['/view', id], {
+      info: {
+        palette: 'new'
+      }
+    });
   }
 }

--- a/src/app/layout/ui/layout-navigation/layout-navigation.component.html
+++ b/src/app/layout/ui/layout-navigation/layout-navigation.component.html
@@ -4,7 +4,7 @@
   @for (navEntry of navigationEntries(); track navEntry.path) {
     <a
       [class]="
-        navEntry.path === currentPath
+        isActive(navEntry.path, currentPath())
           ? 'active scale-105 font-semibold text-blue-500 sm:scale-100 sm:bg-blue-200 sm:font-medium sm:text-blue-700 dark:sm:bg-blue-800 dark:sm:text-blue-200'
           : 'sm:hover:bg-neutral-200 sm:hover:text-neutral-900 dark:sm:hover:bg-neutral-700 dark:sm:hover:text-neutral-50'
       "

--- a/src/app/layout/ui/layout-navigation/layout-navigation.component.ts
+++ b/src/app/layout/ui/layout-navigation/layout-navigation.component.ts
@@ -1,7 +1,9 @@
 import { Component, inject, input } from '@angular/core';
-import { Router, RouterLink } from '@angular/router';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { NavigationEnd, Router, RouterLink } from '@angular/router';
 import { NgIconComponent } from '@ng-icons/core';
 import { TranslateModule } from '@ngx-translate/core';
+import { filter, map } from 'rxjs';
 import { NavigationEntry } from '../../types/navigation-entry';
 
 @Component({
@@ -16,7 +18,21 @@ export class LayoutNavigationComponent {
 
   public readonly navigationEntries = input.required<Array<NavigationEntry>>();
 
-  protected get currentPath(): string {
-    return this._router.url;
+  protected readonly currentPath = toSignal(
+    this._router.events.pipe(
+      filter((event): event is NavigationEnd => event instanceof NavigationEnd),
+      map((event) => event.urlAfterRedirects)
+    ),
+    {
+      initialValue: this._router.url
+    }
+  );
+
+  protected isActive(path: string, url: string): boolean {
+    if (path === '/') {
+      return url === path;
+    } else {
+      return url.startsWith(path);
+    }
   }
 }

--- a/src/app/list/list.component.css
+++ b/src/app/list/list.component.css
@@ -1,0 +1,3 @@
+#list {
+  min-height: calc(100dvh - (var(--header-height) + var(--bottom-navigation-height) + var(--footer-height)));
+}

--- a/src/app/list/list.component.html
+++ b/src/app/list/list.component.html
@@ -3,7 +3,7 @@
     class="mx-auto px-4 py-8 sm:max-w-screen-sm md:max-w-screen-md"
     id="list"
   >
-    <section class="mb-4 flex flex-col items-center gap-2 lg:flex-row lg:items-end lg:justify-between">
+    <section class="mb-4 flex flex-col items-center gap-2 sm:flex-row sm:items-end sm:justify-between">
       <h1 class="select-none text-3xl font-bold lg:text-2xl">
         {{ 'list.title' | translate }}
       </h1>
@@ -25,49 +25,10 @@
       </div>
     </section>
 
-    <section class="rounded-md border border-neutral-200 dark:border-neutral-700">
-      @for (palette of list(); track palette.id) {
-        <div
-          [class.rounded-b-md]="$last"
-          [class.rounded-t-md]="$first"
-          class="group flex items-center justify-between transition-colors duration-300 ease-in-out odd:bg-neutral-100 hover:bg-neutral-200 dark:odd:bg-neutral-800 dark:hover:bg-neutral-700"
-        >
-          <a
-            [routerLink]="['/view', palette.id]"
-            [title]="'list.view' | translate: { name: palette.name }"
-            class="group/link flex h-12 grow items-center gap-2 px-4 sm:h-14"
-          >
-            <span>
-              {{ palette.name }}
-            </span>
-            <span
-              class="flex -translate-x-full items-center justify-center opacity-0 transition-all duration-300 ease-spring group-hover/link:translate-x-0 group-hover/link:opacity-100"
-            >
-              <ng-icon [svg]="heroArrowRightMini" />
-            </span>
-          </a>
-
-          <div
-            class="inline-flex p-2 transition-opacity duration-300 ease-in-out group-hover:opacity-100 can-hover:opacity-0"
-          >
-            <button
-              [title]="'list.delete.hover' | translate"
-              (click)="deletePalette(palette)"
-              class="flex size-8 items-center justify-center rounded border border-transparent text-neutral-700 transition-colors duration-300 ease-in-out hover:border-neutral-300 hover:bg-neutral-100 dark:text-neutral-200 dark:hover:border-neutral-600 dark:hover:bg-neutral-800 sm:size-10"
-            >
-              <span class="sr-only">
-                {{ 'common.delete' | translate }}
-              </span>
-              <ng-icon
-                [svg]="heroTrashMini"
-                class="scale-90 sm:scale-100"
-                size="1.25rem"
-              />
-            </button>
-          </div>
-        </div>
-      }
-    </section>
+    <rp-palette-list
+      [list]="list()"
+      (deletePalette)="deletePalette($event)"
+    />
   </div>
 } @else {
   <rp-no-palette [parent]="'view'" />

--- a/src/app/list/list.component.html
+++ b/src/app/list/list.component.html
@@ -31,5 +31,5 @@
     />
   </div>
 } @else {
-  <rp-no-palette [parent]="'view'" />
+  <rp-no-palette parent="view" />
 }

--- a/src/app/list/list.component.html
+++ b/src/app/list/list.component.html
@@ -1,0 +1,51 @@
+@if (list().length > 0) {
+  <div
+    class="mx-auto px-4 py-8 sm:max-w-screen-sm md:max-w-screen-md"
+    id="list"
+  >
+    <section class="mb-4 flex flex-col items-center gap-2 lg:flex-row lg:items-end lg:justify-between">
+      <h1 class="select-none text-3xl font-bold lg:text-2xl">
+        {{ 'list.title' | translate }}
+      </h1>
+      <div class="flex flex-wrap justify-center gap-2">
+        <a
+          [routerLink]="['/']"
+          [title]="'list.new' | translate"
+          class="flex cursor-pointer items-center gap-2 overflow-hidden rounded bg-blue-500 px-2 py-1.5 font-semibold text-neutral-50 dark:bg-blue-600 sm:px-3 sm:py-2"
+        >
+          <ng-icon
+            [svg]="heroPlusMini"
+            class="scale-90 sm:scale-100"
+            size="1.25rem"
+          />
+          <span>
+            {{ 'list.new' | translate }}
+          </span>
+        </a>
+      </div>
+    </section>
+
+    <section class="rounded-md border border-neutral-200 dark:border-neutral-700">
+      @for (palette of list(); track palette.id) {
+        <a
+          [class.rounded-b-md]="$last"
+          [class.rounded-t-md]="$first"
+          [routerLink]="['/view', palette.id]"
+          [title]="'list.view' | translate: { name: palette.name }"
+          class="group flex items-center justify-between p-4 transition-colors duration-300 ease-in-out odd:bg-neutral-100 hover:bg-neutral-200 dark:odd:bg-neutral-800 dark:hover:bg-neutral-700"
+        >
+          <span>
+            {{ palette.name }}
+          </span>
+          <span
+            class="flex -translate-x-full items-center justify-center opacity-0 transition-all duration-300 ease-in-out group-hover:translate-x-0 group-hover:opacity-100"
+          >
+            <ng-icon [svg]="heroArrowRightMini" />
+          </span>
+        </a>
+      }
+    </section>
+  </div>
+} @else {
+  <rp-no-palette [parent]="'view'" />
+}

--- a/src/app/list/list.component.html
+++ b/src/app/list/list.component.html
@@ -27,22 +27,45 @@
 
     <section class="rounded-md border border-neutral-200 dark:border-neutral-700">
       @for (palette of list(); track palette.id) {
-        <a
+        <div
           [class.rounded-b-md]="$last"
           [class.rounded-t-md]="$first"
-          [routerLink]="['/view', palette.id]"
-          [title]="'list.view' | translate: { name: palette.name }"
-          class="group flex items-center justify-between p-4 transition-colors duration-300 ease-in-out odd:bg-neutral-100 hover:bg-neutral-200 dark:odd:bg-neutral-800 dark:hover:bg-neutral-700"
+          class="group flex items-center justify-between transition-colors duration-300 ease-in-out odd:bg-neutral-100 hover:bg-neutral-200 dark:odd:bg-neutral-800 dark:hover:bg-neutral-700"
         >
-          <span>
-            {{ palette.name }}
-          </span>
-          <span
-            class="flex -translate-x-full items-center justify-center opacity-0 transition-all duration-300 ease-in-out group-hover:translate-x-0 group-hover:opacity-100"
+          <a
+            [routerLink]="['/view', palette.id]"
+            [title]="'list.view' | translate: { name: palette.name }"
+            class="group/link flex h-12 grow items-center gap-2 px-4 sm:h-14"
           >
-            <ng-icon [svg]="heroArrowRightMini" />
-          </span>
-        </a>
+            <span>
+              {{ palette.name }}
+            </span>
+            <span
+              class="flex -translate-x-full items-center justify-center opacity-0 transition-all duration-300 ease-in-out group-hover/link:translate-x-0 group-hover/link:opacity-100"
+            >
+              <ng-icon [svg]="heroArrowRightMini" />
+            </span>
+          </a>
+
+          <div
+            class="inline-flex p-2 transition-opacity duration-300 ease-in-out group-hover:opacity-100 can-hover:opacity-0"
+          >
+            <button
+              [title]="'list.delete.hover' | translate"
+              (click)="deletePalette(palette)"
+              class="flex size-8 items-center justify-center rounded border border-transparent text-neutral-700 transition-colors duration-300 ease-in-out hover:border-neutral-300 hover:bg-neutral-100 dark:text-neutral-200 dark:hover:border-neutral-600 dark:hover:bg-neutral-800 sm:size-10"
+            >
+              <span class="sr-only">
+                {{ 'common.delete' | translate }}
+              </span>
+              <ng-icon
+                [svg]="heroTrashMini"
+                class="scale-90 sm:scale-100"
+                size="1.25rem"
+              />
+            </button>
+          </div>
+        </div>
       }
     </section>
   </div>

--- a/src/app/list/list.component.html
+++ b/src/app/list/list.component.html
@@ -41,7 +41,7 @@
               {{ palette.name }}
             </span>
             <span
-              class="flex -translate-x-full items-center justify-center opacity-0 transition-all duration-300 ease-in-out group-hover/link:translate-x-0 group-hover/link:opacity-100"
+              class="flex -translate-x-full items-center justify-center opacity-0 transition-all duration-300 ease-spring group-hover/link:translate-x-0 group-hover/link:opacity-100"
             >
               <ng-icon [svg]="heroArrowRightMini" />
             </span>

--- a/src/app/list/list.component.spec.ts
+++ b/src/app/list/list.component.spec.ts
@@ -1,0 +1,28 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute } from '@angular/router';
+import { TranslateModule } from '@ngx-translate/core';
+import { ListService, ListServiceMock } from '../shared/data-access/list.service';
+import ListComponent from './list.component';
+
+describe('ListComponent', () => {
+  let component: ListComponent;
+  let fixture: ComponentFixture<ListComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ListComponent, TranslateModule.forRoot()],
+      providers: [
+        { provide: ActivatedRoute, useValue: { snapshot: {} } },
+        { provide: ListService, useClass: ListServiceMock }
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ListComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/list/list.component.spec.ts
+++ b/src/app/list/list.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ActivatedRoute } from '@angular/router';
 import { TranslateModule } from '@ngx-translate/core';
+import { DialogService, DialogServiceMock } from '../shared/data-access/dialog.service';
 import { ListService, ListServiceMock } from '../shared/data-access/list.service';
 import ListComponent from './list.component';
 
@@ -13,7 +14,8 @@ describe('ListComponent', () => {
       imports: [ListComponent, TranslateModule.forRoot()],
       providers: [
         { provide: ActivatedRoute, useValue: { snapshot: {} } },
-        { provide: ListService, useClass: ListServiceMock }
+        { provide: ListService, useClass: ListServiceMock },
+        { provide: DialogService, useClass: DialogServiceMock }
       ]
     }).compileComponents();
 

--- a/src/app/list/list.component.ts
+++ b/src/app/list/list.component.ts
@@ -1,0 +1,26 @@
+import { Component, inject } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { RouterLink } from '@angular/router';
+import { NgIconComponent } from '@ng-icons/core';
+import { heroArrowRightMini, heroPlusMini } from '@ng-icons/heroicons/mini';
+import { TranslateModule } from '@ngx-translate/core';
+import { ListService } from '../shared/data-access/list.service';
+import { NoPaletteComponent } from '../shared/ui/no-palette/no-palette.component';
+
+@Component({
+  selector: 'rp-list',
+  standalone: true,
+  imports: [RouterLink, TranslateModule, NgIconComponent, NoPaletteComponent],
+  templateUrl: './list.component.html',
+  styleUrl: `list.component.css`
+})
+export default class ListComponent {
+  private readonly _listService = inject(ListService);
+
+  protected readonly list = toSignal(this._listService.list$, {
+    initialValue: []
+  });
+
+  protected readonly heroArrowRightMini = heroArrowRightMini;
+  protected readonly heroPlusMini = heroPlusMini;
+}

--- a/src/app/list/list.component.ts
+++ b/src/app/list/list.component.ts
@@ -2,9 +2,10 @@ import { Component, inject } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { RouterLink } from '@angular/router';
 import { NgIconComponent } from '@ng-icons/core';
-import { heroArrowRightMini, heroPlusMini } from '@ng-icons/heroicons/mini';
-import { TranslateModule } from '@ngx-translate/core';
-import { ListService } from '../shared/data-access/list.service';
+import { heroArrowRightMini, heroPlusMini, heroTrashMini } from '@ng-icons/heroicons/mini';
+import { TranslateModule, TranslateService } from '@ngx-translate/core';
+import { DialogService } from '../shared/data-access/dialog.service';
+import { ListService, PaletteListItem } from '../shared/data-access/list.service';
 import { NoPaletteComponent } from '../shared/ui/no-palette/no-palette.component';
 
 @Component({
@@ -16,6 +17,8 @@ import { NoPaletteComponent } from '../shared/ui/no-palette/no-palette.component
 })
 export default class ListComponent {
   private readonly _listService = inject(ListService);
+  private readonly _dialogService = inject(DialogService);
+  private readonly _translateService = inject(TranslateService);
 
   protected readonly list = toSignal(this._listService.list$, {
     initialValue: []
@@ -23,4 +26,16 @@ export default class ListComponent {
 
   protected readonly heroArrowRightMini = heroArrowRightMini;
   protected readonly heroPlusMini = heroPlusMini;
+  protected readonly heroTrashMini = heroTrashMini;
+
+  protected async deletePalette(palette: PaletteListItem): Promise<void> {
+    const shouldDelete = await this._dialogService.confirm(
+      this._translateService.instant('list.delete.dialog', {
+        name: palette.name
+      })
+    );
+    if (shouldDelete) {
+      this._listService.remove(palette.id);
+    }
+  }
 }

--- a/src/app/list/list.component.ts
+++ b/src/app/list/list.component.ts
@@ -2,16 +2,17 @@ import { Component, inject } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { RouterLink } from '@angular/router';
 import { NgIconComponent } from '@ng-icons/core';
-import { heroArrowRightMini, heroPlusMini, heroTrashMini } from '@ng-icons/heroicons/mini';
+import { heroPlusMini } from '@ng-icons/heroicons/mini';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { DialogService } from '../shared/data-access/dialog.service';
 import { ListService, PaletteListItem } from '../shared/data-access/list.service';
 import { NoPaletteComponent } from '../shared/ui/no-palette/no-palette.component';
+import { PaletteListComponent } from './ui/palette-list/palette-list.component';
 
 @Component({
   selector: 'rp-list',
   standalone: true,
-  imports: [RouterLink, TranslateModule, NgIconComponent, NoPaletteComponent],
+  imports: [RouterLink, TranslateModule, NgIconComponent, NoPaletteComponent, PaletteListComponent],
   templateUrl: './list.component.html',
   styleUrl: `list.component.css`
 })
@@ -24,9 +25,7 @@ export default class ListComponent {
     initialValue: []
   });
 
-  protected readonly heroArrowRightMini = heroArrowRightMini;
   protected readonly heroPlusMini = heroPlusMini;
-  protected readonly heroTrashMini = heroTrashMini;
 
   protected async deletePalette(palette: PaletteListItem): Promise<void> {
     const shouldDelete = await this._dialogService.confirm(

--- a/src/app/list/ui/palette-list/palette-list.component.html
+++ b/src/app/list/ui/palette-list/palette-list.component.html
@@ -1,0 +1,43 @@
+<section class="rounded-md border border-neutral-200 dark:border-neutral-700">
+  @for (palette of list(); track palette.id) {
+    <div
+      [class.rounded-b-md]="$last"
+      [class.rounded-t-md]="$first"
+      class="group flex items-center justify-between transition-colors duration-300 ease-in-out odd:bg-neutral-100 hover:bg-neutral-200 dark:odd:bg-neutral-800 dark:hover:bg-neutral-700"
+    >
+      <a
+        [routerLink]="['/view', palette.id]"
+        [title]="'list.view' | translate: { name: palette.name }"
+        class="group/link flex h-12 grow items-center gap-2 px-4 sm:h-14"
+      >
+        <span>
+          {{ palette.name }}
+        </span>
+        <span
+          class="flex -translate-x-full items-center justify-center opacity-0 transition-all duration-300 ease-spring group-hover/link:translate-x-0 group-hover/link:opacity-100"
+        >
+          <ng-icon [svg]="heroArrowRightMini" />
+        </span>
+      </a>
+
+      <div
+        class="inline-flex p-2 transition-opacity duration-300 ease-in-out group-hover:opacity-100 can-hover:opacity-0"
+      >
+        <button
+          [title]="'list.delete.hover' | translate"
+          (click)="deletePalette.emit(palette)"
+          class="flex size-8 items-center justify-center rounded border border-transparent text-neutral-700 transition-colors duration-300 ease-in-out hover:border-neutral-300 hover:bg-neutral-100 dark:text-neutral-200 dark:hover:border-neutral-600 dark:hover:bg-neutral-800 sm:size-10"
+        >
+          <span class="sr-only">
+            {{ 'common.delete' | translate }}
+          </span>
+          <ng-icon
+            [svg]="heroTrashMini"
+            class="scale-90 sm:scale-100"
+            size="1.25rem"
+          />
+        </button>
+      </div>
+    </div>
+  }
+</section>

--- a/src/app/list/ui/palette-list/palette-list.component.spec.ts
+++ b/src/app/list/ui/palette-list/palette-list.component.spec.ts
@@ -1,0 +1,35 @@
+import { signal } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute } from '@angular/router';
+import { TranslateModule } from '@ngx-translate/core';
+import { PaletteListItem } from '../../../shared/data-access/list.service';
+import { PaletteListComponent } from './palette-list.component';
+
+describe('PaletteListComponent', () => {
+  let component: PaletteListComponent;
+  let fixture: ComponentFixture<PaletteListComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [PaletteListComponent, TranslateModule.forRoot()],
+      providers: [{ provide: ActivatedRoute, useValue: {} }]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(PaletteListComponent);
+    component = fixture.componentInstance;
+
+    // @ts-expect-error Input is required
+    component.list = signal<Array<PaletteListItem>>([
+      {
+        id: 'palette1',
+        name: 'Rainbow'
+      }
+    ]);
+
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/list/ui/palette-list/palette-list.component.stories.ts
+++ b/src/app/list/ui/palette-list/palette-list.component.stories.ts
@@ -1,0 +1,60 @@
+import { ActivatedRoute } from '@angular/router';
+import { Meta, moduleMetadata } from '@storybook/angular';
+import { createStory } from '../../../shared/utils/storybook';
+import { PaletteListComponent } from './palette-list.component';
+
+const meta: Meta<PaletteListComponent> = {
+  title: 'List/Palette List',
+  component: PaletteListComponent,
+  decorators: [
+    moduleMetadata({
+      providers: [{ provide: ActivatedRoute, useValue: {} }]
+    })
+  ],
+  tags: ['autodocs'],
+  argTypes: {
+    list: {
+      type: {
+        name: 'array',
+        required: true,
+        value: {
+          name: 'object',
+          value: {
+            id: {
+              name: 'string',
+              required: true
+            },
+            name: {
+              name: 'string',
+              required: true
+            }
+          }
+        }
+      }
+    }
+  }
+};
+export default meta;
+
+export const List = createStory<PaletteListComponent>({
+  args: {
+    list: [
+      {
+        id: 'palette1',
+        name: 'Rainbow'
+      },
+      {
+        id: 'palette2',
+        name: 'Sunset'
+      },
+      {
+        id: 'palette3',
+        name: 'Ocean'
+      },
+      {
+        id: 'palette4',
+        name: 'Forest'
+      }
+    ]
+  }
+});

--- a/src/app/list/ui/palette-list/palette-list.component.ts
+++ b/src/app/list/ui/palette-list/palette-list.component.ts
@@ -1,0 +1,27 @@
+import { Component, input, output } from '@angular/core';
+import { RouterLink } from '@angular/router';
+import { NgIconComponent } from '@ng-icons/core';
+import { heroArrowRightMini, heroTrashMini } from '@ng-icons/heroicons/mini';
+import { TranslateModule } from '@ngx-translate/core';
+import { PaletteListItem } from '../../../shared/data-access/list.service';
+
+@Component({
+  selector: 'rp-palette-list',
+  standalone: true,
+  imports: [RouterLink, TranslateModule, NgIconComponent],
+  templateUrl: './palette-list.component.html'
+})
+export class PaletteListComponent {
+  /**
+   * The list of palettes to display.
+   */
+  public readonly list = input.required<Array<PaletteListItem>>();
+
+  /**
+   * Emits when a palette is selected.
+   */
+  public readonly deletePalette = output<PaletteListItem>();
+
+  protected readonly heroArrowRightMini = heroArrowRightMini;
+  protected readonly heroTrashMini = heroTrashMini;
+}

--- a/src/app/shared/data-access/analytics.service.spec.ts
+++ b/src/app/shared/data-access/analytics.service.spec.ts
@@ -86,7 +86,8 @@ describe('AnalyticsService', () => {
   });
 
   afterEach(() => {
-    localStorage.clear();
+    localStorage.removeItem(LocalStorageKey.ANALYTICS);
+    localStorage.removeItem(LocalStorageKey.USER_ID);
   });
 });
 
@@ -120,5 +121,10 @@ describe('AnalyticsService', () => {
 
     await sleep(5);
     expect(tracker.setCustomDimension).toHaveBeenCalledTimes(3);
+  });
+
+  afterEach(() => {
+    localStorage.removeItem(LocalStorageKey.ANALYTICS);
+    localStorage.removeItem(LocalStorageKey.USER_ID);
   });
 });

--- a/src/app/shared/data-access/list.service.spec.ts
+++ b/src/app/shared/data-access/list.service.spec.ts
@@ -1,13 +1,22 @@
 import { TestBed } from '@angular/core/testing';
 import { firstValueFrom } from 'rxjs';
+import { TailwindGrays } from '../constants/tailwind-colors';
 import { LocalStorageKey } from '../enums/local-storage-keys';
-import { ListService } from './list.service';
+import { Palette } from '../model';
+import { ListService, PaletteListItem } from './list.service';
+
+const predefined: PaletteListItem = {
+  id: 'predefined',
+  name: 'Predefined Palette'
+};
+
+const predefinedPalette = new Palette(predefined.name, [], predefined.id);
 
 describe('ListService', () => {
   let service: ListService;
 
   beforeEach(() => {
-    localStorage.setItem(LocalStorageKey.PALETTE_IDS, '["predefined"]');
+    localStorage.setItem(LocalStorageKey.PALETTE_IDS, JSON.stringify([predefined]));
 
     TestBed.configureTestingModule({});
     service = TestBed.inject(ListService);
@@ -17,21 +26,27 @@ describe('ListService', () => {
     expect(service).toBeTruthy();
 
     const list = await firstValueFrom(service.list$);
-    expect(list).toContain('predefined');
+    expect(list.length).toBe(1);
+    expect(list[0].id).toBe('predefined');
+    expect(list[0].name).toBe('Predefined Palette');
   });
 
   it('should add a palette id to the list', async () => {
-    service.add('test-id');
+    const palette = TailwindGrays;
+    service.add(palette);
 
     const list = await firstValueFrom(service.list$);
-    expect(list).toContain('test-id');
+    expect(list.length).toBe(2);
+
+    const item = list.find((i) => i.id === palette.id);
+    expect(item).toBeTruthy();
   });
 
   it('should not add a palette id to the list if it already exists', async () => {
-    service.add('predefined');
+    service.add(predefinedPalette);
 
     const list = await firstValueFrom(service.list$);
-    expect(list).toEqual(['predefined']);
+    expect(list.length).toBe(1);
   });
 
   it('should remove a palette id from the list', async () => {
@@ -45,7 +60,7 @@ describe('ListService', () => {
     service.remove('test-id');
 
     const list = await firstValueFrom(service.list$);
-    expect(list).toEqual(['predefined']);
+    expect(list.length).toBe(1);
   });
 
   afterEach(() => {

--- a/src/app/shared/data-access/list.service.spec.ts
+++ b/src/app/shared/data-access/list.service.spec.ts
@@ -1,0 +1,54 @@
+import { TestBed } from '@angular/core/testing';
+import { firstValueFrom } from 'rxjs';
+import { LocalStorageKey } from '../enums/local-storage-keys';
+import { ListService } from './list.service';
+
+describe('ListService', () => {
+  let service: ListService;
+
+  beforeEach(() => {
+    localStorage.setItem(LocalStorageKey.PALETTE_IDS, '["predefined"]');
+
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(ListService);
+  });
+
+  it('should be created', async () => {
+    expect(service).toBeTruthy();
+
+    const list = await firstValueFrom(service.list$);
+    expect(list).toContain('predefined');
+  });
+
+  it('should add a palette id to the list', async () => {
+    service.add('test-id');
+
+    const list = await firstValueFrom(service.list$);
+    expect(list).toContain('test-id');
+  });
+
+  it('should not add a palette id to the list if it already exists', async () => {
+    service.add('predefined');
+
+    const list = await firstValueFrom(service.list$);
+    expect(list).toEqual(['predefined']);
+  });
+
+  it('should remove a palette id from the list', async () => {
+    service.remove('predefined');
+
+    const list = await firstValueFrom(service.list$);
+    expect(list).toEqual([]);
+  });
+
+  it('should not remove a palette id from the list if it does not exist', async () => {
+    service.remove('test-id');
+
+    const list = await firstValueFrom(service.list$);
+    expect(list).toEqual(['predefined']);
+  });
+
+  afterEach(() => {
+    localStorage.removeItem(LocalStorageKey.PALETTE_IDS);
+  });
+});

--- a/src/app/shared/data-access/list.service.ts
+++ b/src/app/shared/data-access/list.service.ts
@@ -63,6 +63,9 @@ export class ListService {
     if (index > -1) {
       const list = this._list$.value;
       list.splice(index, 1);
+
+      localStorage.removeItem(`${LocalStorageKey.PALETTE}_${id}`);
+
       this._list$.next(list);
     }
   }

--- a/src/app/shared/data-access/list.service.ts
+++ b/src/app/shared/data-access/list.service.ts
@@ -1,6 +1,12 @@
 import { Injectable } from '@angular/core';
 import { BehaviorSubject } from 'rxjs';
 import { LocalStorageKey } from '../enums/local-storage-keys';
+import { Palette } from '../model';
+
+export type PaletteListItem = {
+  id: string;
+  name: string;
+};
 
 @Injectable({
   providedIn: 'root'
@@ -9,7 +15,7 @@ export class ListService {
   /**
    * List of palette ids stored in local storage
    */
-  private readonly _list$ = new BehaviorSubject<Array<string>>([]);
+  private readonly _list$ = new BehaviorSubject<Array<PaletteListItem>>([]);
 
   /**
    * List of palette ids stored in local storage
@@ -38,17 +44,22 @@ export class ListService {
   /**
    * Add a palette id to the list
    */
-  public add(id: string): void {
-    if (!this._list$.value.includes(id)) {
-      this._list$.next([...this._list$.value, id]);
+  public add(palette: Palette): void {
+    const list = this._list$.value;
+
+    const index = list.findIndex((item) => item.id === palette.id);
+    if (index > -1) {
+      list.splice(index, 1);
     }
+
+    this._list$.next([{ id: palette.id, name: palette.name }, ...list]);
   }
 
   /**
    * Remove a palette id from the list
    */
   public remove(id: string): void {
-    const index = this._list$.value.indexOf(id);
+    const index = this._list$.value.findIndex((item) => item.id === id);
     if (index > -1) {
       const list = this._list$.value;
       list.splice(index, 1);
@@ -58,7 +69,7 @@ export class ListService {
 }
 
 export class ListServiceMock {
-  public add(_id: string): void {}
+  public add(_palette: Palette): void {}
   public remove(_id: string): void {}
-  public list$ = new BehaviorSubject<Array<string>>([]).asObservable();
+  public list$ = new BehaviorSubject<Array<PaletteListItem>>([]).asObservable();
 }

--- a/src/app/shared/data-access/list.service.ts
+++ b/src/app/shared/data-access/list.service.ts
@@ -1,0 +1,64 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+import { LocalStorageKey } from '../enums/local-storage-keys';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ListService {
+  /**
+   * List of palette ids stored in local storage
+   */
+  private readonly _list$ = new BehaviorSubject<Array<string>>([]);
+
+  /**
+   * List of palette ids stored in local storage
+   */
+  public readonly list$ = this._list$.asObservable();
+
+  public constructor() {
+    // Load list from local storage
+    const list = localStorage.getItem(LocalStorageKey.PALETTE_IDS);
+
+    // If there is a list in local storage, parse it and update the list subject
+    if (list) {
+      try {
+        this._list$.next(JSON.parse(list));
+      } catch (e) {
+        console.error('Could not parse list from local storage.', e);
+      }
+    }
+
+    // Update list in local storage when it changes
+    this.list$.subscribe((list) => {
+      localStorage.setItem(LocalStorageKey.PALETTE_IDS, JSON.stringify(list));
+    });
+  }
+
+  /**
+   * Add a palette id to the list
+   */
+  public add(id: string): void {
+    if (!this._list$.value.includes(id)) {
+      this._list$.next([...this._list$.value, id]);
+    }
+  }
+
+  /**
+   * Remove a palette id from the list
+   */
+  public remove(id: string): void {
+    const index = this._list$.value.indexOf(id);
+    if (index > -1) {
+      const list = this._list$.value;
+      list.splice(index, 1);
+      this._list$.next(list);
+    }
+  }
+}
+
+export class ListServiceMock {
+  public add(_id: string): void {}
+  public remove(_id: string): void {}
+  public list$ = new BehaviorSubject<Array<string>>([]).asObservable();
+}

--- a/src/app/shared/data-access/list.service.ts
+++ b/src/app/shared/data-access/list.service.ts
@@ -71,5 +71,5 @@ export class ListService {
 export class ListServiceMock {
   public add(_palette: Palette): void {}
   public remove(_id: string): void {}
-  public list$ = new BehaviorSubject<Array<PaletteListItem>>([]).asObservable();
+  public list$ = new BehaviorSubject<Array<PaletteListItem>>([{ id: 'test-id', name: 'Test palette' }]).asObservable();
 }

--- a/src/app/shared/data-access/palette.service.spec.ts
+++ b/src/app/shared/data-access/palette.service.spec.ts
@@ -3,6 +3,7 @@ import { PaletteScheme } from '../constants/palette-scheme';
 import { LocalStorageKey } from '../enums/local-storage-keys';
 import { ColorNameService, ColorNameServiceMock } from './color-name.service';
 import { ColorService, ColorServiceMock } from './color.service';
+import { ListService, ListServiceMock } from './list.service';
 import { PaletteService } from './palette.service';
 import { ToastService, ToastServiceMock } from './toast.service';
 
@@ -10,12 +11,14 @@ describe('PaletteService', () => {
   let colorService: ColorServiceMock;
   let colorNameService: ColorNameServiceMock;
   let toastService: ToastServiceMock;
+  let listService: ListServiceMock;
   let service: PaletteService;
 
   beforeEach(() => {
     colorService = new ColorServiceMock();
     colorNameService = new ColorNameServiceMock();
     toastService = new ToastServiceMock();
+    listService = new ListServiceMock();
 
     TestBed.configureTestingModule({
       providers: [
@@ -24,6 +27,10 @@ describe('PaletteService', () => {
         {
           provide: ToastService,
           useValue: toastService
+        },
+        {
+          provide: ListService,
+          useValue: listService
         }
       ]
     });
@@ -50,30 +57,37 @@ describe('PaletteService', () => {
     await service.generatePalette('#ffffff', PaletteScheme.COMPLEMENTARY);
     service.savePaletteToLocalStorage();
 
-    expect(localStorage.getItem(LocalStorageKey.PALETTE)).toBeTruthy();
-    expect(localStorage.getItem(LocalStorageKey.PALETTE)).toContain('name');
-    expect(localStorage.getItem(LocalStorageKey.PALETTE)).toContain('colors');
+    const palette = service.palette();
+    expect(palette).toBeTruthy();
+
+    expect(localStorage.getItem(`${LocalStorageKey.PALETTE}_${palette!.id}`)).toBeTruthy();
+    expect(localStorage.getItem(`${LocalStorageKey.PALETTE}_${palette!.id}`)).toContain('id');
+    expect(localStorage.getItem(`${LocalStorageKey.PALETTE}_${palette!.id}`)).toContain('name');
+    expect(localStorage.getItem(`${LocalStorageKey.PALETTE}_${palette!.id}`)).toContain('colors');
     expect(colorService.regenerateShades).toHaveBeenCalledTimes(3);
     expect(colorNameService.getColorName).toHaveBeenCalledTimes(3);
+
+    localStorage.removeItem(`${LocalStorageKey.PALETTE}_${palette!.id}`);
   });
 
   it('should load palette from local storage', () => {
-    localStorage.setItem(LocalStorageKey.PALETTE, JSON.stringify({ name: 'Test', colors: [] }));
-    service.loadPaletteFromLocalStorage();
+    localStorage.setItem(`${LocalStorageKey.PALETTE}_test`, JSON.stringify({ name: 'Test', id: 'test', colors: [] }));
+    service.loadPaletteFromLocalStorage('test');
 
     const palette = service.palette();
     expect(palette).toBeTruthy();
     expect(palette!.name).toBe('Test');
+    expect(palette!.id).toBe('test');
   });
 
   it('should show error toast when loading invalid palette', () => {
-    localStorage.setItem(LocalStorageKey.PALETTE, 'invalid');
-    service.loadPaletteFromLocalStorage();
+    localStorage.setItem(`${LocalStorageKey.PALETTE}_test`, 'invalid');
+    service.loadPaletteFromLocalStorage('test');
 
     expect(toastService.showToast).toHaveBeenCalled();
   });
 
   afterEach(() => {
-    localStorage.removeItem(LocalStorageKey.PALETTE);
+    localStorage.removeItem(`${LocalStorageKey.PALETTE}_test`);
   });
 });

--- a/src/app/shared/data-access/palette.service.ts
+++ b/src/app/shared/data-access/palette.service.ts
@@ -51,7 +51,7 @@ export class PaletteService {
       try {
         const palette = Palette.parse(oldPalette);
         localStorage.setItem(`${LocalStorageKey.PALETTE}_${palette.id}`, palette.toString());
-        this._listService.add(palette.id);
+        this._listService.add(palette);
 
         localStorage.removeItem(LocalStorageKey.PALETTE);
       } catch (e) {
@@ -64,6 +64,10 @@ export class PaletteService {
   }
 
   public loadPaletteFromLocalStorage(id: string): void {
+    if (this.palette()?.id === id) {
+      return;
+    }
+
     // Check if there was a palette stored for an app update
     let palette = localStorage.getItem(LocalStorageKey.PALETTE_TMP);
 
@@ -95,12 +99,12 @@ export class PaletteService {
         localStorage.setItem(LocalStorageKey.PALETTE_TMP, palette.toString());
       } else {
         localStorage.setItem(`${LocalStorageKey.PALETTE}_${palette.id}`, palette.toString());
-        this._listService.add(palette.id);
+        this._listService.add(palette);
       }
     }
   }
 
-  public async generatePalette(hex: string, scheme: PaletteScheme): Promise<void> {
+  public async generatePalette(hex: string, scheme: PaletteScheme): Promise<string> {
     const palette = await this._generatePalette(hex, scheme);
 
     for (const color of palette.colors) {
@@ -112,6 +116,8 @@ export class PaletteService {
     }
 
     this._palette.set(palette);
+
+    return palette.id;
   }
 
   private async _generatePalette(hex: string, scheme: PaletteScheme): Promise<Palette> {
@@ -526,8 +532,12 @@ export class PaletteService {
 }
 
 export class PaletteServiceMock {
-  public palette = signal<Palette | undefined>(new Palette('Mock', [new Color([Shade.random()], 'MockColor')]));
+  public palette = signal<Palette | undefined>(
+    new Palette('Mock', [new Color([Shade.random()], 'MockColor')], 'test-id')
+  );
   public loadPaletteFromLocalStorage(): void {}
   public savePaletteToLocalStorage(): void {}
-  public generatePalette(_hex: string, _scheme: PaletteScheme): void {}
+  public generatePalette(_hex: string, _scheme: PaletteScheme): string {
+    return 'test-id';
+  }
 }

--- a/src/app/shared/data-access/palette.service.ts
+++ b/src/app/shared/data-access/palette.service.ts
@@ -34,7 +34,7 @@ export class PaletteService {
     this._listService.list$
       .pipe(
         take(1),
-        map((list) => list[0])
+        map((list) => list[0].id)
       )
       .subscribe((id) => {
         this.loadPaletteFromLocalStorage(id);

--- a/src/app/shared/data-access/palette.service.ts
+++ b/src/app/shared/data-access/palette.service.ts
@@ -1,5 +1,4 @@
 import { Injectable, Signal, effect, inject, signal } from '@angular/core';
-import { map, take } from 'rxjs';
 import { PaletteScheme } from '../constants/palette-scheme';
 import { LocalStorageKey } from '../enums/local-storage-keys';
 import { Value } from '../model';
@@ -29,16 +28,6 @@ export class PaletteService {
   public constructor() {
     // Migrate single palette to list
     this._migratePalette();
-
-    // Load the palette from local storage
-    this._listService.list$
-      .pipe(
-        take(1),
-        map((list) => list[0].id)
-      )
-      .subscribe((id) => {
-        this.loadPaletteFromLocalStorage(id);
-      });
 
     effect(() => {
       this._updateVariables();

--- a/src/app/shared/enums/local-storage-keys.ts
+++ b/src/app/shared/enums/local-storage-keys.ts
@@ -27,6 +27,10 @@ export enum LocalStorageKey {
    */
   PALETTE = 'RP_PALETTE',
   /**
+   * Store a list of all palette ids created by the user.
+   */
+  PALETTE_IDS = 'RP_PALETTE_IDS',
+  /**
    * Temporarily store the user's palette while the app updates itself.
    */
   PALETTE_TMP = 'RP_PALETTE_TMP',

--- a/src/app/shared/model/palette.model.spec.ts
+++ b/src/app/shared/model/palette.model.spec.ts
@@ -9,39 +9,44 @@ describe('Palette', () => {
   });
 
   it('should parse palette from string', () => {
-    const palette = Palette.parse(`{"name":"Test","colors":[]}`);
+    const palette = Palette.parse(`{"id": "test-id", "name":"Test","colors":[]}`);
 
     expect(palette).toBeInstanceOf(Palette);
+    expect(palette.id).toBe('test-id');
     expect(palette.name).toBe('Test');
     expect(palette.colors.length).toBe(0);
   });
 
   it('should parse palette from object', () => {
     const palette = Palette.parse({
+      id: 'test-id',
       name: 'Test',
       colors: [new Color([Shade.random()], 'TestColor')]
     });
 
     expect(palette).toBeInstanceOf(Palette);
+    expect(palette.id).toBe('test-id');
     expect(palette.name).toBe('Test');
     expect(palette.colors.length).toBe(1);
   });
 
   it('should stringify and re-parse palette', () => {
-    const palette = new Palette('Test', [new Color([Shade.random()], 'TestColor')]);
+    const palette = new Palette('Test', [new Color([Shade.random()], 'TestColor')], 'test-id');
     const parsed = Palette.parse(palette.toString());
 
     expect(parsed).toBeInstanceOf(Palette);
+    expect(parsed.id).toBe('test-id');
     expect(parsed.name).toBe('Test');
     expect(parsed.colors.length).toBe(1);
   });
 
   it('should copy palette', () => {
     const palette = Tailwind;
-    const copy = palette.copy();
+    const copy = palette.copy(true);
 
     expect(copy).toBeInstanceOf(Palette);
     expect(copy).not.toBe(palette);
+    expect(copy.id).toBe(palette.id);
     expect(copy.name).toBe(palette.name);
     expect(copy.colors.length).toBe(palette.colors.length);
     expect(copy.toString()).toBe(palette.toString());

--- a/src/app/shared/model/palette.model.ts
+++ b/src/app/shared/model/palette.model.ts
@@ -24,11 +24,11 @@ export class Palette {
     }
   }
 
-  public copy(copyId: boolean): Palette {
+  public copy(shouldCopyId: boolean): Palette {
     return new Palette(
       this.name,
       this.colors.map((color) => color.copy()),
-      copyId ? this.id : undefined
+      shouldCopyId ? this.id : undefined
     );
   }
 

--- a/src/app/shared/model/palette.model.ts
+++ b/src/app/shared/model/palette.model.ts
@@ -1,12 +1,16 @@
+import { generateId } from '../utils/generate-id';
 import { Color } from './color.model';
 
 export class Palette {
+  public readonly id: string;
   public name: string;
   public readonly colors: Array<Color>;
 
-  public constructor(name: string, colors: Array<Color>) {
+  public constructor(name: string, colors: Array<Color>, id?: string) {
     this.colors = colors;
     this.name = name;
+
+    this.id = id || generateId(15);
   }
 
   public addColor(color: Color): void {
@@ -20,10 +24,11 @@ export class Palette {
     }
   }
 
-  public copy(): Palette {
+  public copy(copyId: boolean): Palette {
     return new Palette(
       this.name,
-      this.colors.map((color) => color.copy())
+      this.colors.map((color) => color.copy()),
+      copyId ? this.id : undefined
     );
   }
 
@@ -49,6 +54,11 @@ export class Palette {
       name = palette.name;
     }
 
+    let id: string | undefined;
+    if ('id' in palette && typeof palette.id === 'string') {
+      id = palette.id;
+    }
+
     const colors: Array<Color> = [];
     if (!Array.isArray(palette.colors)) {
       throw new Error(`Could not parse palette (invalid "colors" property): "${palette.colors}"`);
@@ -62,13 +72,14 @@ export class Palette {
       }
     }
 
-    return new Palette(name || 'Palette', colors);
+    return new Palette(name || 'Palette', colors, id);
   }
 
   public toJSON(): object {
     return {
       name: this.name,
-      colors: this.colors.map((color) => color.toJSON())
+      colors: this.colors.map((color) => color.toJSON()),
+      id: this.id
     };
   }
 

--- a/src/app/shared/ui/accordion/accordion.component.html
+++ b/src/app/shared/ui/accordion/accordion.component.html
@@ -19,7 +19,7 @@
     >
       <ng-icon
         [svg]="heroPlus"
-        class="inset-0 transition group-open:rotate-45"
+        class="inset-0 transition duration-300 ease-spring group-open:rotate-45"
         size="1.25rem"
       />
     </span>

--- a/src/app/shared/ui/accordion/accordion.component.ts
+++ b/src/app/shared/ui/accordion/accordion.component.ts
@@ -151,7 +151,7 @@ export class AccordionComponent {
       },
       {
         duration: 300,
-        easing: 'ease-in-out'
+        easing: 'ease-in'
       }
     );
 

--- a/src/app/shared/ui/dropdown-menu/dropdown-menu.component.stories.ts
+++ b/src/app/shared/ui/dropdown-menu/dropdown-menu.component.stories.ts
@@ -9,7 +9,7 @@ const meta: Meta<DropdownMenuComponent<string>> = {
   argTypes: {
     items: {
       control: {
-        type: 'array'
+        type: 'object'
       }
     },
     disabled: {

--- a/src/app/shared/ui/no-palette/no-palette.component.html
+++ b/src/app/shared/ui/no-palette/no-palette.component.html
@@ -14,7 +14,7 @@
     </p>
 
     <a
-      [routerLink]="'/'"
+      [routerLink]="parent() === 'palette' ? ['/view'] : ['/']"
       class="inline-flex items-center gap-2 rounded-md bg-blue-500 px-4 py-2 font-semibold text-neutral-50 dark:bg-blue-600"
     >
       <ng-icon
@@ -22,7 +22,7 @@
         size="1.1rem"
         strokeWidth="0.15rem"
       />
-      {{ 'no-palette.link' | translate }}
+      {{ (parent() === 'palette' ? 'no-palette.link.list' : 'no-palette.link.generate') | translate }}
     </a>
   </article>
 </section>

--- a/src/app/shared/ui/no-palette/no-palette.component.stories.ts
+++ b/src/app/shared/ui/no-palette/no-palette.component.stories.ts
@@ -16,7 +16,7 @@ const meta: Meta<NoPaletteComponent> = {
     parent: {
       type: {
         name: 'enum',
-        value: ['view', 'preview'],
+        value: ['view', 'palette', 'preview'],
         required: true
       }
     }
@@ -27,6 +27,11 @@ export default meta;
 export const View = createStory<NoPaletteComponent>({
   args: {
     parent: 'view'
+  }
+});
+export const Palette = createStory<NoPaletteComponent>({
+  args: {
+    parent: 'palette'
   }
 });
 export const Preview = createStory<NoPaletteComponent>({

--- a/src/app/shared/ui/no-palette/no-palette.component.ts
+++ b/src/app/shared/ui/no-palette/no-palette.component.ts
@@ -18,5 +18,5 @@ export class NoPaletteComponent {
    * The parent component of the no-palette component.
    * This determines the text that is displayed in the no-palette component.
    */
-  public readonly parent = input.required<'view' | 'preview'>();
+  public readonly parent = input.required<'view' | 'palette' | 'preview'>();
 }

--- a/src/app/shared/utils/generate-id.ts
+++ b/src/app/shared/utils/generate-id.ts
@@ -1,0 +1,13 @@
+/**
+ * Generate a random id with the specified length.
+ * The id contains only lowercase letters and numbers.
+ *
+ * @param length The length of the id.
+ */
+export function generateId(length: number): string {
+  let result = '';
+  do {
+    result += Math.random().toString(36).substring(2, 9);
+  } while (result.length < length);
+  return result.substring(0, length);
+}

--- a/src/app/view/utils/unsaved-changes.guard.ts
+++ b/src/app/view/utils/unsaved-changes.guard.ts
@@ -1,14 +1,14 @@
-import { inject } from '@angular/core';
+import { Signal, inject } from '@angular/core';
 import { CanDeactivateFn } from '@angular/router';
 import { TranslateService } from '@ngx-translate/core';
 import { DialogService } from '../../shared/data-access/dialog.service';
 
 export interface UnsavedChangesComponent {
-  hasUnsavedChanges: boolean;
+  hasUnsavedChanges: Signal<boolean>;
 }
 
 export const unsavedChangesGuard: CanDeactivateFn<UnsavedChangesComponent> = async (component) => {
-  if (!component.hasUnsavedChanges) {
+  if (!component.hasUnsavedChanges()) {
     return true;
   }
 

--- a/src/app/view/utils/unsaved-changes.guard.ts
+++ b/src/app/view/utils/unsaved-changes.guard.ts
@@ -1,0 +1,20 @@
+import { inject } from '@angular/core';
+import { CanDeactivateFn } from '@angular/router';
+import { TranslateService } from '@ngx-translate/core';
+import { DialogService } from '../../shared/data-access/dialog.service';
+
+export interface UnsavedChangesComponent {
+  hasUnsavedChanges: boolean;
+}
+
+export const unsavedChangesGuard: CanDeactivateFn<UnsavedChangesComponent> = async (component) => {
+  if (!component.hasUnsavedChanges) {
+    return true;
+  }
+
+  const dialogService = inject(DialogService);
+  const translateService = inject(TranslateService);
+  const leave = await dialogService.confirm(translateService.instant('view.unsaved-changes'));
+
+  return leave;
+};

--- a/src/app/view/view.component.html
+++ b/src/app/view/view.component.html
@@ -96,5 +96,5 @@
     </section>
   </div>
 } @else {
-  <rp-no-palette [parent]="'palette'" />
+  <rp-no-palette parent="palette" />
 }

--- a/src/app/view/view.component.html
+++ b/src/app/view/view.component.html
@@ -1,5 +1,18 @@
 @if (palette(); as palette) {
   <div class="mx-auto px-4 py-8 sm:max-w-screen-sm lg:max-w-screen-lg">
+    <a
+      [routerLink]="['/view']"
+      class="group -ml-4 mb-4 inline-flex items-center gap-1 rounded px-4 py-2 font-medium transition-colors duration-300 ease-in-out hover:bg-blue-200 hover:text-blue-700 dark:hover:bg-blue-800 dark:hover:text-blue-200"
+    >
+      <ng-icon
+        [svg]="heroArrowLeftMini"
+        class="transition-transform duration-300 ease-in-out group-hover:-translate-x-1"
+      />
+      <span>
+        {{ 'view.back' | translate }}
+      </span>
+    </a>
+
     <section class="mb-4 flex flex-col items-center gap-2 lg:flex-row lg:items-end lg:justify-between">
       <h1 class="select-none text-3xl font-bold lg:text-2xl">
         {{ palette.name }}

--- a/src/app/view/view.component.html
+++ b/src/app/view/view.component.html
@@ -6,7 +6,7 @@
     >
       <ng-icon
         [svg]="heroArrowLeftMini"
-        class="transition-transform duration-300 ease-in-out group-hover:-translate-x-1"
+        class="transition-transform duration-300 ease-spring group-hover:-translate-x-1"
       />
       <span>
         {{ 'view.back' | translate }}

--- a/src/app/view/view.component.html
+++ b/src/app/view/view.component.html
@@ -83,5 +83,5 @@
     </section>
   </div>
 } @else {
-  <rp-no-palette [parent]="'view'" />
+  <rp-no-palette [parent]="'palette'" />
 }

--- a/src/app/view/view.component.html
+++ b/src/app/view/view.component.html
@@ -50,12 +50,16 @@
         </button>
 
         <button
-          [disabled]="saving()"
-          [title]="(saving() ? 'view.palette.saving' : 'view.palette.save') | translate"
+          [class]="saving() ? 'cursor-wait' : hasUnsavedChanges() ? 'cursor-pointer' : 'cursor-not-allowed'"
+          [disabled]="saving() || !hasUnsavedChanges()"
+          [title]="saveTooltip() | translate"
           (click)="savePalette()"
-          class="group flex cursor-pointer items-center gap-2 overflow-hidden rounded bg-blue-500 px-2 py-1.5 font-semibold text-neutral-50 disabled:cursor-wait disabled:bg-neutral-400 dark:bg-blue-600 dark:disabled:bg-neutral-700 sm:px-3 sm:py-2"
+          class="flex items-center gap-2 overflow-hidden rounded bg-blue-500 px-2 py-1.5 font-semibold text-neutral-50 disabled:bg-neutral-400 dark:bg-blue-600 dark:disabled:bg-neutral-700 sm:px-3 sm:py-2"
         >
-          <span class="flex items-center justify-center group-disabled:animate-pulse-spin">
+          <span
+            [class.animate-pulse-spin]="saving()"
+            class="flex items-center justify-center"
+          >
             <ng-icon
               [svg]="saveIcon()"
               class="scale-90 sm:scale-100"

--- a/src/app/view/view.component.spec.ts
+++ b/src/app/view/view.component.spec.ts
@@ -70,6 +70,7 @@ describe('ViewComponent', () => {
 
     expect(dialogService.prompt).toHaveBeenCalledTimes(1);
     expect(toastService.showToast).toHaveBeenCalledTimes(1);
+    expect(component.hasUnsavedChanges).toBeTrue();
   });
 
   it('should save palette', async () => {
@@ -85,6 +86,7 @@ describe('ViewComponent', () => {
       TrackingEventCategory.SAVE_PALETTE,
       TrackingEventAction.SAVE_PALETTE_LOCAL_STORAGE
     );
+    expect(component.hasUnsavedChanges).toBeFalse();
   });
 
   it('should open color rename dialog', async () => {
@@ -97,6 +99,7 @@ describe('ViewComponent', () => {
     expect(color.name).toBe('Color_test');
     expect(dialogService.prompt).toHaveBeenCalledTimes(1);
     expect(toastService.showToast).toHaveBeenCalledTimes(1);
+    expect(component.hasUnsavedChanges).toBeTrue();
   });
 
   it('should confirm color delete', async () => {
@@ -108,6 +111,7 @@ describe('ViewComponent', () => {
 
     expect(dialogService.confirm).toHaveBeenCalledTimes(1);
     expect(toastService.showToast).toHaveBeenCalledTimes(1);
+    expect(component.hasUnsavedChanges).toBeTrue();
   });
 
   it('should open color editor on color edit', async () => {
@@ -118,6 +122,7 @@ describe('ViewComponent', () => {
 
     expect(colorEditorService.openColorEditor).toHaveBeenCalledTimes(1);
     expect(colorEditorService.openColorEditor).toHaveBeenCalledWith(color, 5);
+    expect(component.hasUnsavedChanges).toBeTrue();
   });
 
   it('should add random color', async () => {
@@ -126,6 +131,7 @@ describe('ViewComponent', () => {
     await component.addColor();
 
     expect(colorService.randomColor).toHaveBeenCalledTimes(1);
+    expect(component.hasUnsavedChanges).toBeTrue();
   });
 
   it('should open export modal', async () => {

--- a/src/app/view/view.component.spec.ts
+++ b/src/app/view/view.component.spec.ts
@@ -70,7 +70,7 @@ describe('ViewComponent', () => {
 
     expect(dialogService.prompt).toHaveBeenCalledTimes(1);
     expect(toastService.showToast).toHaveBeenCalledTimes(1);
-    expect(component.hasUnsavedChanges).toBeTrue();
+    expect(component.hasUnsavedChanges()).toBeTrue();
   });
 
   it('should save palette', async () => {
@@ -86,7 +86,7 @@ describe('ViewComponent', () => {
       TrackingEventCategory.SAVE_PALETTE,
       TrackingEventAction.SAVE_PALETTE_LOCAL_STORAGE
     );
-    expect(component.hasUnsavedChanges).toBeFalse();
+    expect(component.hasUnsavedChanges()).toBeFalse();
   });
 
   it('should open color rename dialog', async () => {
@@ -99,7 +99,7 @@ describe('ViewComponent', () => {
     expect(color.name).toBe('Color_test');
     expect(dialogService.prompt).toHaveBeenCalledTimes(1);
     expect(toastService.showToast).toHaveBeenCalledTimes(1);
-    expect(component.hasUnsavedChanges).toBeTrue();
+    expect(component.hasUnsavedChanges()).toBeTrue();
   });
 
   it('should confirm color delete', async () => {
@@ -111,7 +111,7 @@ describe('ViewComponent', () => {
 
     expect(dialogService.confirm).toHaveBeenCalledTimes(1);
     expect(toastService.showToast).toHaveBeenCalledTimes(1);
-    expect(component.hasUnsavedChanges).toBeTrue();
+    expect(component.hasUnsavedChanges()).toBeTrue();
   });
 
   it('should open color editor on color edit', async () => {
@@ -122,7 +122,7 @@ describe('ViewComponent', () => {
 
     expect(colorEditorService.openColorEditor).toHaveBeenCalledTimes(1);
     expect(colorEditorService.openColorEditor).toHaveBeenCalledWith(color, 5);
-    expect(component.hasUnsavedChanges).toBeTrue();
+    expect(component.hasUnsavedChanges()).toBeTrue();
   });
 
   it('should add random color', async () => {
@@ -131,7 +131,7 @@ describe('ViewComponent', () => {
     await component.addColor();
 
     expect(colorService.randomColor).toHaveBeenCalledTimes(1);
-    expect(component.hasUnsavedChanges).toBeTrue();
+    expect(component.hasUnsavedChanges()).toBeTrue();
   });
 
   it('should open export modal', async () => {

--- a/src/app/view/view.component.spec.ts
+++ b/src/app/view/view.component.spec.ts
@@ -1,3 +1,4 @@
+import { signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ActivatedRoute } from '@angular/router';
 import { TranslateModule } from '@ngx-translate/core';
@@ -50,6 +51,10 @@ describe('ViewComponent', () => {
 
     fixture = TestBed.createComponent(ViewComponent);
     component = fixture.componentInstance;
+
+    // @ts-expect-error - read-only property
+    component.id = signal('test');
+
     fixture.detectChanges();
   });
 

--- a/src/app/view/view.component.ts
+++ b/src/app/view/view.component.ts
@@ -1,7 +1,9 @@
 import { Component, OnInit, computed, inject, input, signal } from '@angular/core';
+import { RouterLink } from '@angular/router';
 import { NgIconComponent } from '@ng-icons/core';
 import {
   heroArrowDownTrayMini,
+  heroArrowLeftMini,
   heroArrowPathMini,
   heroBookmarkMini,
   heroPencilSquareMini,
@@ -26,7 +28,7 @@ import { ViewPaletteComponent } from './ui/view-palette/view-palette.component';
 @Component({
   selector: 'rp-view',
   standalone: true,
-  imports: [ViewPaletteComponent, NoPaletteComponent, NgIconComponent, TranslateModule],
+  imports: [ViewPaletteComponent, NoPaletteComponent, NgIconComponent, TranslateModule, RouterLink],
   templateUrl: './view.component.html'
 })
 export default class ViewComponent implements OnInit {
@@ -43,6 +45,7 @@ export default class ViewComponent implements OnInit {
   protected readonly heroPencilSquareMini = heroPencilSquareMini;
   protected readonly heroPlusMini = heroPlusMini;
   protected readonly heroArrowDownTrayMini = heroArrowDownTrayMini;
+  protected readonly heroArrowLeftMini = heroArrowLeftMini;
 
   public readonly id = input.required<string>();
 

--- a/src/app/view/view.component.ts
+++ b/src/app/view/view.component.ts
@@ -24,6 +24,7 @@ import { NoPaletteComponent } from '../shared/ui/no-palette/no-palette.component
 import { IS_RUNNING_TEST } from '../shared/utils/is-running-test';
 import { sleep } from '../shared/utils/sleep';
 import { ViewPaletteComponent } from './ui/view-palette/view-palette.component';
+import { UnsavedChangesComponent } from './utils/unsaved-changes.guard';
 
 @Component({
   selector: 'rp-view',
@@ -31,7 +32,7 @@ import { ViewPaletteComponent } from './ui/view-palette/view-palette.component';
   imports: [ViewPaletteComponent, NoPaletteComponent, NgIconComponent, TranslateModule, RouterLink],
   templateUrl: './view.component.html'
 })
-export default class ViewComponent implements OnInit {
+export default class ViewComponent implements OnInit, UnsavedChangesComponent {
   private readonly _isRunningTest = inject(IS_RUNNING_TEST);
   private readonly _colorEditorService = inject(ColorEditorService);
   private readonly _toastService = inject(ToastService);
@@ -51,6 +52,12 @@ export default class ViewComponent implements OnInit {
 
   protected readonly palette = this._paletteService.palette;
   protected readonly saving = signal(false);
+
+  private _hasUnsavedChanges = false;
+
+  public get hasUnsavedChanges(): boolean {
+    return this._hasUnsavedChanges;
+  }
 
   public ngOnInit(): void {
     this._paletteService.loadPaletteFromLocalStorage(this.id());
@@ -88,6 +95,7 @@ export default class ViewComponent implements OnInit {
       message: 'view.palette.renamed',
       parameters: { name: newName }
     });
+    this._hasUnsavedChanges = true;
   }
 
   public async savePalette(): Promise<void> {
@@ -113,6 +121,7 @@ export default class ViewComponent implements OnInit {
       type: 'success',
       message: 'view.palette.saved'
     });
+    this._hasUnsavedChanges = false;
   }
 
   public async exportPalette(): Promise<void> {
@@ -140,6 +149,7 @@ export default class ViewComponent implements OnInit {
       message: 'view.color.renamed',
       parameters: { name: newName }
     });
+    this._hasUnsavedChanges = true;
   }
 
   public async editColor(color: Color, shadeIndex?: number): Promise<void> {
@@ -150,6 +160,7 @@ export default class ViewComponent implements OnInit {
     }
 
     color.shades = updatedColor.shades;
+    this._hasUnsavedChanges = true;
   }
 
   public async removeColor(color: Color): Promise<void> {
@@ -168,6 +179,7 @@ export default class ViewComponent implements OnInit {
         message: 'view.color.removed',
         parameters: { color: name }
       });
+      this._hasUnsavedChanges = true;
     }
   }
 
@@ -179,6 +191,7 @@ export default class ViewComponent implements OnInit {
 
     const color = await this._colorService.randomColor();
     palette.addColor(color);
+    this._hasUnsavedChanges = true;
   }
 
   public async copyToClipboard(shade: Shade): Promise<void> {

--- a/src/app/view/view.component.ts
+++ b/src/app/view/view.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, computed, inject, input, signal } from '@angular/core';
+import { Component, HostListener, OnInit, computed, inject, input, signal } from '@angular/core';
 import { Router, RouterLink } from '@angular/router';
 import { NgIconComponent } from '@ng-icons/core';
 import {
@@ -226,5 +226,23 @@ export default class ViewComponent implements OnInit, UnsavedChangesComponent {
         message: 'view.color.copy.error'
       });
     }
+  }
+
+  /**
+   * Check if there are unsaved changes before leaving the page.
+   * This method exists in addition to the normal `canDeactivate` guard
+   * and is used to prevent the user from accidentally leaving the page.
+   * The route guard is not enough because it only prevents navigation
+   * inside the app, but not when the user closes the browser tab.
+   */
+  @HostListener('window:beforeunload', ['$event'])
+  public checkUnsavedChanges(_: Event): boolean {
+    // If there are unsaved changes, show a confirmation dialog by returning false
+    if (this.hasUnsavedChanges()) {
+      return false;
+    }
+
+    // There are no unsaved changes, so the user can leave the page
+    return true;
   }
 }

--- a/src/app/view/view.component.ts
+++ b/src/app/view/view.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, computed, inject, input, signal } from '@angular/core';
-import { RouterLink } from '@angular/router';
+import { Router, RouterLink } from '@angular/router';
 import { NgIconComponent } from '@ng-icons/core';
 import {
   heroArrowDownTrayMini,
@@ -42,6 +42,7 @@ export default class ViewComponent implements OnInit, UnsavedChangesComponent {
   private readonly _dialogService = inject(DialogService);
   private readonly _exportService = inject(ExportModalService);
   private readonly _analyticsService = inject(AnalyticsService);
+  private readonly _router = inject(Router);
 
   protected readonly heroPencilSquareMini = heroPencilSquareMini;
   protected readonly heroPlusMini = heroPlusMini;
@@ -60,7 +61,15 @@ export default class ViewComponent implements OnInit, UnsavedChangesComponent {
   }
 
   public ngOnInit(): void {
+    // Load the palette from local storage
     this._paletteService.loadPaletteFromLocalStorage(this.id());
+
+    // Check is the palette is new
+    const navigation = this._router.lastSuccessfulNavigation;
+    const info = navigation?.extras.info as { palette: 'new' } | undefined;
+    if (info?.palette === 'new') {
+      this._hasUnsavedChanges = true;
+    }
   }
 
   protected readonly saveIcon = computed(() => {

--- a/src/app/view/view.component.ts
+++ b/src/app/view/view.component.ts
@@ -54,11 +54,7 @@ export default class ViewComponent implements OnInit, UnsavedChangesComponent {
   protected readonly palette = this._paletteService.palette;
   protected readonly saving = signal(false);
 
-  private _hasUnsavedChanges = false;
-
-  public get hasUnsavedChanges(): boolean {
-    return this._hasUnsavedChanges;
-  }
+  private readonly _hasUnsavedChanges = signal(false);
 
   public ngOnInit(): void {
     // Load the palette from local storage
@@ -68,7 +64,7 @@ export default class ViewComponent implements OnInit, UnsavedChangesComponent {
     const navigation = this._router.lastSuccessfulNavigation;
     const info = navigation?.extras.info as { palette: 'new' } | undefined;
     if (info?.palette === 'new') {
-      this._hasUnsavedChanges = true;
+      this._hasUnsavedChanges.set(true);
     }
   }
 
@@ -77,6 +73,18 @@ export default class ViewComponent implements OnInit, UnsavedChangesComponent {
       return heroArrowPathMini;
     } else {
       return heroBookmarkMini;
+    }
+  });
+
+  public readonly hasUnsavedChanges = computed(() => this._hasUnsavedChanges());
+
+  public readonly saveTooltip = computed(() => {
+    if (this.saving()) {
+      return 'view.palette.saving';
+    } else if (this.hasUnsavedChanges()) {
+      return 'view.palette.save';
+    } else {
+      return 'view.palette.no-changes';
     }
   });
 
@@ -104,7 +112,7 @@ export default class ViewComponent implements OnInit, UnsavedChangesComponent {
       message: 'view.palette.renamed',
       parameters: { name: newName }
     });
-    this._hasUnsavedChanges = true;
+    this._hasUnsavedChanges.set(true);
   }
 
   public async savePalette(): Promise<void> {
@@ -130,7 +138,7 @@ export default class ViewComponent implements OnInit, UnsavedChangesComponent {
       type: 'success',
       message: 'view.palette.saved'
     });
-    this._hasUnsavedChanges = false;
+    this._hasUnsavedChanges.set(false);
   }
 
   public async exportPalette(): Promise<void> {
@@ -158,7 +166,7 @@ export default class ViewComponent implements OnInit, UnsavedChangesComponent {
       message: 'view.color.renamed',
       parameters: { name: newName }
     });
-    this._hasUnsavedChanges = true;
+    this._hasUnsavedChanges.set(true);
   }
 
   public async editColor(color: Color, shadeIndex?: number): Promise<void> {
@@ -169,7 +177,7 @@ export default class ViewComponent implements OnInit, UnsavedChangesComponent {
     }
 
     color.shades = updatedColor.shades;
-    this._hasUnsavedChanges = true;
+    this._hasUnsavedChanges.set(true);
   }
 
   public async removeColor(color: Color): Promise<void> {
@@ -188,7 +196,7 @@ export default class ViewComponent implements OnInit, UnsavedChangesComponent {
         message: 'view.color.removed',
         parameters: { color: name }
       });
-      this._hasUnsavedChanges = true;
+      this._hasUnsavedChanges.set(true);
     }
   }
 
@@ -200,7 +208,7 @@ export default class ViewComponent implements OnInit, UnsavedChangesComponent {
 
     const color = await this._colorService.randomColor();
     palette.addColor(color);
-    this._hasUnsavedChanges = true;
+    this._hasUnsavedChanges.set(true);
   }
 
   public async copyToClipboard(shade: Shade): Promise<void> {

--- a/src/app/view/view.component.ts
+++ b/src/app/view/view.component.ts
@@ -1,4 +1,4 @@
-import { Component, computed, inject, signal } from '@angular/core';
+import { Component, OnInit, computed, inject, input, signal } from '@angular/core';
 import { NgIconComponent } from '@ng-icons/core';
 import {
   heroArrowDownTrayMini,
@@ -29,7 +29,7 @@ import { ViewPaletteComponent } from './ui/view-palette/view-palette.component';
   imports: [ViewPaletteComponent, NoPaletteComponent, NgIconComponent, TranslateModule],
   templateUrl: './view.component.html'
 })
-export default class ViewComponent {
+export default class ViewComponent implements OnInit {
   private readonly _isRunningTest = inject(IS_RUNNING_TEST);
   private readonly _colorEditorService = inject(ColorEditorService);
   private readonly _toastService = inject(ToastService);
@@ -44,8 +44,14 @@ export default class ViewComponent {
   protected readonly heroPlusMini = heroPlusMini;
   protected readonly heroArrowDownTrayMini = heroArrowDownTrayMini;
 
+  public readonly id = input.required<string>();
+
   protected readonly palette = this._paletteService.palette;
   protected readonly saving = signal(false);
+
+  public ngOnInit(): void {
+    this._paletteService.loadPaletteFromLocalStorage(this.id());
+  }
 
   protected readonly saveIcon = computed(() => {
     if (this.saving()) {

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -208,8 +208,14 @@
       "theme": "Wähle ein Design"
     }
   },
+  "list": {
+    "new": "Neue Palette",
+    "title": "Deine Farbpaletten",
+    "view": "Palette \"{{ name }}\" ansehen"
+  },
   "no-palette": {
     "description": {
+      "palette": "Es wurde keine Palette mit der angegebenen ID gefunden. Vielleicht hast du dich vertippt oder die Palette wurde gelöscht.",
       "preview": "Du hast noch keine Farbpalette erstellt. Sobald du eine Palette generiert hast, kannst du hier eine Vorschau sehen und die Palette ausprobieren.",
       "view": "Du hast noch keine Farbpalette erstellt. Sobald du eine Palette generiert hast, kannst du sie hier bearbeiten und anpassen."
     },

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -266,6 +266,7 @@
     }
   },
   "view": {
+    "back": "Zurück zur Übersicht",
     "color": {
       "add": "Farbe hinzufügen",
       "add-tooltip": "Füge deiner Palette eine neue Farbe hinzu",

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -223,7 +223,10 @@
       "preview": "Du hast noch keine Farbpalette erstellt. Sobald du eine Palette generiert hast, kannst du hier eine Vorschau sehen und die Palette ausprobieren.",
       "view": "Du hast noch keine Farbpalette erstellt. Sobald du eine Palette generiert hast, kannst du sie hier bearbeiten und anpassen."
     },
-    "link": "Zurück zum Generator",
+    "link": {
+      "generate": "Zurück zum Generator",
+      "list": "Zurück zur Übersicht"
+    },
     "title": "Keine Farbpalette vorhanden"
   },
   "preview": {

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -283,6 +283,7 @@
       "tune": "Passe die Farbe nach deinem Geschmack an"
     },
     "palette": {
+      "no-changes": "Es wurden noch keine Änderungen an deiner Palette vorgenommen.",
       "rename": "Gebe deiner Palette einen neuen Namen",
       "renamed": "Deine Palette wurde in \"{{ palette }}\" umbenannt.",
       "save": "Speichere die Palette in deinem Browser",

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -209,6 +209,10 @@
     }
   },
   "list": {
+    "delete": {
+      "dialog": "Bist du sicher, dass du die Palette \"{{ name }}\" löschen möchtest?\n\nDie Palette kann nicht wiederhergestellt werden.",
+      "hover": "Palette löschen"
+    },
     "new": "Neue Palette",
     "title": "Deine Farbpaletten",
     "view": "Palette \"{{ name }}\" ansehen"

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -288,6 +288,7 @@
       "save": "Speichere die Palette in deinem Browser",
       "saved": "Deine Palette wurde lokal gespeichert.",
       "saving": "Deine Palette wird im Browser gespeichert"
-    }
+    },
+    "unsaved-changes": "Die Änderungen an deiner Palette wurden noch nicht gespeichert. Wenn du die Seite verlässt, gehen alle Änderungen verloren.\n\nBist du sicher, dass du die Seite verlassen möchtest?"
   }
 }

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -210,6 +210,10 @@
     }
   },
   "list": {
+    "delete": {
+      "dialog": "Are you sure you want to delete the palette \"{{ name }}\"?\n\nThis action cannot be undone.",
+      "hover": "Delete palette"
+    },
     "new": "New palette",
     "title": "Your palettes",
     "view": "View palette \"{{ name }}\""

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -209,8 +209,14 @@
       "theme": "Pick a theme"
     }
   },
+  "list": {
+    "new": "New palette",
+    "title": "Your palettes",
+    "view": "View palette \"{{ name }}\""
+  },
   "no-palette": {
     "description": {
+      "palette": "There was no palette found with the given ID. Maybe you have entered the wrong URL or the palette has been deleted.",
       "preview": "You don't have a palette yet. You have to generate one first before you can preview it.",
       "view": "You don't have a palette yet. You have to generate one first before you can edit it."
     },

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -267,6 +267,7 @@
     }
   },
   "view": {
+    "back": "Back to your palettes",
     "color": {
       "add": "Add color",
       "add-tooltip": "Add a new color to your palette",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -284,6 +284,7 @@
       "tune": "Tune the color to your liking"
     },
     "palette": {
+      "no-changes": "No changes have been made to your palette yet.",
       "rename": "Give your palette a new name",
       "renamed": "Your palette has been renamed to \"{{ name }}\".",
       "save": "Save your palette in your browser",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -224,7 +224,10 @@
       "preview": "You don't have a palette yet. You have to generate one first before you can preview it.",
       "view": "You don't have a palette yet. You have to generate one first before you can edit it."
     },
-    "link": "Back to generation",
+    "link": {
+      "generate": "Back to generation",
+      "list": "Back to your palettes"
+    },
     "title": "No palette available"
   },
   "preview": {

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -289,6 +289,7 @@
       "save": "Save your palette in your browser",
       "saved": "Your palette has been saved.",
       "saving": "Saving your palette in your browser"
-    }
+    },
+    "unsaved-changes": "You have unsaved changes in your palette. If you leave this page, your changes will be lost.\n\nAre you sure you want to leave?"
   }
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,28 +1,35 @@
-const defaultTheme = require("tailwindcss/defaultTheme");
-const plugin = require("tailwindcss/plugin");
+const defaultTheme = require('tailwindcss/defaultTheme');
+const plugin = require('tailwindcss/plugin');
 
 /** @type {import('tailwindcss').Config} */
 module.exports = {
-  content: ["./src/**/*{html,ts}"],
-  darkMode: "class",
+  content: ['./src/**/*{html,ts}'],
+  darkMode: 'class',
   theme: {
     extend: {
       animation: {
-        "pulse-spin": "spin 1s ease-in-out infinite",
+        'pulse-spin': 'spin 1s ease-in-out infinite'
       },
       backdropBlur: {
-        xs: "2px",
-      },
+        xs: '2px'
+      }
     },
     screens: {
-      xs: "425px",
-      ...defaultTheme.screens,
-    },
+      xs: '425px',
+      ...defaultTheme.screens
+    }
   },
   plugins: [
-    require("@tailwindcss/forms"),
+    require('@tailwindcss/forms'),
     plugin(({ addVariant }) => {
-      addVariant("hocus", ["&:hover", "&:focus"]);
+      addVariant('hocus', ['&:hover', '&:focus']);
     }),
-  ],
+    plugin(({ addVariant }) => {
+      addVariant('no-hover', '@media (hover: none)');
+      addVariant('can-hover', '@media (hover: hover)');
+      addVariant('pointer-coarse', '@media (pointer: coarse)');
+      addVariant('pointer-fine', '@media (pointer: fine)');
+      addVariant('pointer-none', '@media (pointer: none)');
+    })
+  ]
 };

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -12,6 +12,9 @@ module.exports = {
       },
       backdropBlur: {
         xs: '2px'
+      },
+      transitionTimingFunction: {
+        spring: 'cubic-bezier(.4,1.75,.6,1)'
       }
     },
     screens: {


### PR DESCRIPTION
## Issues

- #60 

## Changes

- Add new view for list of palettes
- Warn user about unsaved changes
- Add list of palettes into localStorage
- Save palette with id in localStorage key (with automatic migration for existing palette)
- Autogenerate id for palettes
- Add new spring animation
- Compare routes for top navigation for similarity instead of strict equality