### PR TITLE
Add automatic theme switcher

### DIFF
--- a/src/app/layout/constants/themes.ts
+++ b/src/app/layout/constants/themes.ts
@@ -1,7 +1,9 @@
+import { heroAdjustmentsVerticalMini } from '@ng-icons/heroicons/mini';
 import { heroMoonSolid, heroSunSolid } from '@ng-icons/heroicons/solid';
 import { ThemeOption } from '../../shared/types/theme';
 
 export const THEME_OPTIONS: Array<ThemeOption> = [
+  { value: 'auto', label: 'theme.auto', icon: heroAdjustmentsVerticalMini },
   { value: 'light', label: 'theme.light', icon: heroSunSolid },
   { value: 'dark', label: 'theme.dark', icon: heroMoonSolid }
 ];

--- a/src/app/layout/layout.component.ts
+++ b/src/app/layout/layout.component.ts
@@ -56,7 +56,7 @@ export class LayoutComponent implements AfterViewInit {
   private readonly _resize = toSignal(fromEvent(window, 'resize'));
 
   protected readonly logoAsset = computed(() => {
-    return this.theme() === 'dark' ? '/assets/rainbow-palette-light.svg' : '/assets/rainbow-palette-dark.svg';
+    return this._themeService.isDark() ? '/assets/rainbow-palette-light.svg' : '/assets/rainbow-palette-dark.svg';
   });
 
   protected readonly showAnalyticsConsent = computed(() => {

--- a/src/app/layout/ui/layout-navigation/layout-navigation.component.stories.ts
+++ b/src/app/layout/ui/layout-navigation/layout-navigation.component.stories.ts
@@ -53,8 +53,7 @@ const meta: Meta<LayoutNavigationComponent> = {
 };
 export default meta;
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const Navigation = createStory<LayoutNavigationComponent>({
+export const Navigation = createStory<LayoutNavigationComponent>({
   args: {
     navigationEntries: NAVIGATION_ENTRIES
   }

--- a/src/app/layout/ui/layout-options/layout-options.component.stories.ts
+++ b/src/app/layout/ui/layout-options/layout-options.component.stories.ts
@@ -20,7 +20,7 @@ const meta: Meta<LayoutOptionsComponent> = {
       defaultValue: 'light',
       type: {
         name: 'enum',
-        value: ['light', 'dark'],
+        value: ['auto', 'light', 'dark'],
         required: true
       },
       control: 'select'

--- a/src/app/loading/loading.component.ts
+++ b/src/app/loading/loading.component.ts
@@ -14,9 +14,7 @@ export class LoadingComponent {
   private readonly _mobileService = inject(MobileService);
 
   protected readonly logoAsset = computed(() => {
-    return this._themeService.theme() === 'dark'
-      ? '/assets/rainbow-palette-light.svg'
-      : '/assets/rainbow-palette-dark.svg';
+    return this._themeService.isDark() ? '/assets/rainbow-palette-light.svg' : '/assets/rainbow-palette-dark.svg';
   });
 
   protected readonly isMobile = this._mobileService.isMobile;

--- a/src/app/shared/data-access/theme.service.spec.ts
+++ b/src/app/shared/data-access/theme.service.spec.ts
@@ -15,17 +15,22 @@ describe('ThemeService', () => {
     expect(service).toBeTruthy();
   });
 
-  it('should set default theme by user preference', () => {
+  it('should set auto theme by user preference', () => {
+    service.setTheme('auto');
+
     const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-    expect(service.theme()).toBe(prefersDark ? 'dark' : 'light');
+    expect(service.theme()).toBe('auto');
+    expect(service.isDark()).toBe(prefersDark);
   });
 
   it('should change theme', () => {
     service.setTheme('dark');
     expect(service.theme()).toBe('dark');
+    expect(service.isDark()).toBe(true);
 
     service.setTheme('light');
     expect(service.theme()).toBe('light');
+    expect(service.isDark()).toBe(false);
   });
 
   it('should save theme changes to local storage', async () => {
@@ -36,6 +41,10 @@ describe('ThemeService', () => {
     service.setTheme('light');
     await sleep(10);
     expect(localStorage.getItem(LocalStorageKey.THEME)).toBe('light');
+
+    service.setTheme('auto');
+    await sleep(10);
+    expect(localStorage.getItem(LocalStorageKey.THEME)).toBe('auto');
   });
 
   afterEach(() => {
@@ -62,6 +71,20 @@ describe('ThemeService', () => {
     const service = TestBed.inject(ThemeService);
     await sleep(10);
     expect(service.theme()).toBe('light');
+
+    localStorage.removeItem(LocalStorageKey.THEME);
+  });
+
+  it('should set auto theme from local storage on initialization', async () => {
+    localStorage.setItem(LocalStorageKey.THEME, 'auto');
+    TestBed.configureTestingModule({});
+
+    const service = TestBed.inject(ThemeService);
+    await sleep(10);
+    expect(service.theme()).toBe('auto');
+
+    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    expect(service.isDark()).toBe(prefersDark);
 
     localStorage.removeItem(LocalStorageKey.THEME);
   });

--- a/src/app/shared/data-access/theme.service.ts
+++ b/src/app/shared/data-access/theme.service.ts
@@ -1,37 +1,75 @@
-import { Injectable, Signal, effect, signal } from '@angular/core';
+import { Injectable, computed, effect, signal } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { fromEvent, map } from 'rxjs';
 import { LocalStorageKey } from '../enums/local-storage-keys';
 import { Theme } from '../types/theme';
+
+const THEME_QUERY_LIST = matchMedia('(prefers-color-scheme: dark)');
 
 @Injectable({
   providedIn: 'root'
 })
 export class ThemeService {
-  private readonly _theme = signal<Theme>('light');
+  /**
+   * Internal signal to store the current theme.
+   */
+  private readonly _theme = signal<Theme>('auto');
+  /**
+   * Internal flag that reflects the user's preference for dark mode.
+   * This is set in the settings of the operating system or browser and is used when the theme is set to `auto`.
+   *
+   * We also listen to changes to this flag to update the theme when the user changes their preference in real-time.
+   */
+  private readonly _prefersDark = toSignal(
+    fromEvent<MediaQueryListEvent>(THEME_QUERY_LIST, 'change').pipe(map((event) => event.matches)),
+    {
+      initialValue: THEME_QUERY_LIST.matches
+    }
+  );
 
-  public get theme(): Signal<Theme> {
-    return this._theme.asReadonly();
-  }
+  /**
+   * Flag that indicates whether the current theme is dark.
+   */
+  public readonly isDark = computed(() => {
+    const theme = this._theme();
+
+    if (theme === 'auto') {
+      return this._prefersDark();
+    }
+
+    return theme === 'dark';
+  });
+
+  /**
+   * Current theme.
+   */
+  public readonly theme = this._theme.asReadonly();
 
   public constructor() {
-    effect(async () => {
+    // Store the current theme in local storage.
+    effect(() => {
       localStorage.setItem(LocalStorageKey.THEME, this._theme());
-      document.documentElement.classList.toggle('dark', this._theme() === 'dark');
     });
 
+    // Add / remove the 'dark' class based on the current theme.
+    effect(() => {
+      document.documentElement.classList.toggle('dark', this.isDark());
+    });
+
+    // Read the last selected theme from local storage.
     const storedTheme = localStorage.getItem(LocalStorageKey.THEME);
     if (storedTheme === 'dark') {
       this._theme.set('dark');
-      return;
     } else if (storedTheme === 'light') {
-      return;
-    }
-
-    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-    if (prefersDark) {
-      this._theme.set('dark');
+      this._theme.set('light');
+    } else {
+      this._theme.set('auto');
     }
   }
 
+  /**
+   * Set the current theme.
+   */
   public setTheme(theme: Theme): void {
     this._theme.set(theme);
   }
@@ -39,5 +77,6 @@ export class ThemeService {
 
 export class ThemeServiceMock {
   public readonly theme = signal<Theme>('light').asReadonly();
+  public readonly isDark = computed(() => this.theme() === 'dark');
   public setTheme(_theme: Theme): void {}
 }

--- a/src/app/shared/types/theme.ts
+++ b/src/app/shared/types/theme.ts
@@ -3,7 +3,7 @@ import { IconType } from '@ng-icons/core';
 /**
  * A theme type.
  */
-export type Theme = 'light' | 'dark';
+export type Theme = 'auto' | 'light' | 'dark';
 
 /**
  * A theme option for the layout options.

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -252,6 +252,7 @@
     "triadic": "Triadisch"
   },
   "theme": {
+    "auto": "Automatisch",
     "dark": "Dunkel",
     "light": "Hell"
   },

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -253,6 +253,7 @@
     "triadic": "Triadic"
   },
   "theme": {
+    "auto": "Automatic",
     "dark": "Dark",
     "light": "Light"
   },


### PR DESCRIPTION
### Issues
- #66 

### Changes
- Add `auto` theme that always uses a users preferred theme
- Export story of `LayoutNavigationComponent` that was missing for some reason