### PR TITLE
AI generated palette

### DIFF
--- a/.storybook/tsconfig.json
+++ b/.storybook/tsconfig.json
@@ -6,6 +6,6 @@
     "resolveJsonModule": true
   },
   "exclude": ["../src/test.ts", "../src/**/*.spec.ts"],
-  "include": ["../src/**/*.stories.*", "./preview.ts"],
+  "include": ["../src/**/*.stories.*", "./preview.ts", "../src/**/*.d.ts"],
   "files": ["./typings.d.ts"]
 }

--- a/src/app/shared/constants/palette-scheme.ts
+++ b/src/app/shared/constants/palette-scheme.ts
@@ -1,6 +1,7 @@
 export enum PaletteScheme {
   RAINBOW = 'rainbow',
   SURPRISE = 'surprise',
+  AI = 'ai',
   MONOCHROME = 'monochrome',
   ANALOGOUS = 'analogous',
   COMPLEMENTARY = 'complementary',
@@ -23,12 +24,17 @@ export const PALETTE_SCHEMES = [
   { value: PaletteScheme.COMPOUND, label: 'scheme.compound' }
 ];
 
+if (window.ai) {
+  PALETTE_SCHEMES.splice(2, 0, { value: PaletteScheme.AI, label: 'scheme.ai' });
+}
+
 /**
  * Get a random color palette scheme.
  */
 export function randomScheme(): { value: PaletteScheme; label: string } {
-  // Exclude the surprise scheme as it doesn't make sense here
-  const schemes = PALETTE_SCHEMES.filter((scheme) => scheme.value !== PaletteScheme.SURPRISE);
+  // Exclude the surprise and AI schemes as they don't make sense here
+  const excluded = new Set([PaletteScheme.SURPRISE, PaletteScheme.AI]);
+  const schemes = PALETTE_SCHEMES.filter((scheme) => !excluded.has(scheme.value));
 
   return schemes[Math.floor(Math.random() * schemes.length)];
 }

--- a/src/app/shared/data-access/ai.service.spec.ts
+++ b/src/app/shared/data-access/ai.service.spec.ts
@@ -1,0 +1,65 @@
+import { TestBed } from '@angular/core/testing';
+import { IS_RUNNING_TEST } from '../utils/is-running-test';
+import { AiService } from './ai.service';
+import { ColorNameService, ColorNameServiceMock } from './color-name.service';
+
+describe('AiService', () => {
+  let service: AiService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: IS_RUNNING_TEST, useValue: true },
+        {
+          provide: ColorNameService,
+          useClass: ColorNameServiceMock
+        }
+      ]
+    });
+    service = TestBed.inject(AiService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  if (window.ai) {
+    describe('AI is available', () => {
+      it('should be available', () => {
+        expect(service.isAvailable).toBeTrue();
+      });
+
+      it('should prompt', async () => {
+        /*
+         * During testing, the timeout is set to 10ms and the AI will take longer than 10ms to respond.
+         * This test only checks if the API is still working since the error message will be different.
+         * Changes to the API are expected, since the API is still experimental.
+         */
+        await expectAsync(service.prompt('Test')).toBeRejectedWithError('AI took too long to respond');
+      });
+
+      it('should generate palette', async () => {
+        /*
+         * During testing, the timeout is set to 10ms and the AI will take longer than 10ms to respond.
+         * This test only checks if the API is still working since the error message will be different.
+         * Changes to the API are expected, since the API is still experimental.
+         */
+        await expectAsync(service.generatePalette('#000000')).toBeRejectedWithError('AI failed to generate a palette');
+      });
+    });
+  } else {
+    describe('AI is not available', () => {
+      it('should be unavailable', () => {
+        expect(service.isAvailable).toBeFalse();
+      });
+
+      it('should throw an error when prompting', async () => {
+        await expectAsync(service.prompt('Test')).toBeRejectedWithError('AI is not available');
+      });
+
+      it('should throw an error when generating palette', async () => {
+        await expectAsync(service.generatePalette('#000000')).toBeRejectedWithError('AI is not available');
+      });
+    });
+  }
+});

--- a/src/app/shared/data-access/ai.service.ts
+++ b/src/app/shared/data-access/ai.service.ts
@@ -37,23 +37,10 @@ export class AiService {
       return this.#session;
     }
 
-    // Create a new generic session if possible
-    const canCreateGenericSession = await window.ai.canCreateGenericSession();
-    if (canCreateGenericSession === 'readily') {
-      const options = await window.ai.defaultGenericSessionOptions();
-      this.#session = await window.ai.createGenericSession({
-        ...options,
-        temperature: 0.6
-      });
-      return this.#session;
-    }
-
     // Create a new text session if possible
     const canCreateTextSession = await window.ai.canCreateTextSession();
     if (canCreateTextSession === 'readily') {
-      const options = await window.ai.defaultTextSessionOptions();
       this.#session = await window.ai.createTextSession({
-        ...options,
         temperature: 0.6
       });
       return this.#session;

--- a/src/app/shared/data-access/ai.service.ts
+++ b/src/app/shared/data-access/ai.service.ts
@@ -1,0 +1,227 @@
+import { Injectable, inject } from '@angular/core';
+import { ChromeAISession } from '../../../global';
+import { randomScheme } from '../constants/palette-scheme';
+import { Color, Palette, Shade, Value } from '../model';
+import { IS_RUNNING_TEST } from '../utils/is-running-test';
+import { sleep } from '../utils/sleep';
+import { ColorNameService } from './color-name.service';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class AiService {
+  readonly #colorNameService = inject(ColorNameService);
+  readonly #isRunningTest = inject(IS_RUNNING_TEST);
+
+  /**
+   * Flag to indicate whether the local AI is available.
+   */
+  public readonly isAvailable = !!window.ai;
+
+  /**
+   * The AI session.
+   */
+  #session?: ChromeAISession;
+
+  /**
+   * Creates a new session with the local AI.
+   */
+  private async createSession(): Promise<ChromeAISession> {
+    // Check if the AI is available
+    if (!window.ai) {
+      throw new Error('AI is not available');
+    }
+
+    // Check if a session already exists
+    if (this.#session) {
+      return this.#session;
+    }
+
+    // Create a new generic session if possible
+    const canCreateGenericSession = await window.ai.canCreateGenericSession();
+    if (canCreateGenericSession === 'readily') {
+      const options = await window.ai.defaultGenericSessionOptions();
+      this.#session = await window.ai.createGenericSession({
+        ...options,
+        temperature: 0.6
+      });
+      return this.#session;
+    }
+
+    // Create a new text session if possible
+    const canCreateTextSession = await window.ai.canCreateTextSession();
+    if (canCreateTextSession === 'readily') {
+      const options = await window.ai.defaultTextSessionOptions();
+      this.#session = await window.ai.createTextSession({
+        ...options,
+        temperature: 0.6
+      });
+      return this.#session;
+    }
+
+    // No session could be created
+    throw new Error('AI is not available');
+  }
+
+  /**
+   * Sends the given prompt to the AI and returns the response.
+   * This method will throw an error if the AI takes too long to respond.
+   */
+  public async prompt(prompt: string): Promise<string> {
+    // Check if the AI is available
+    if (!this.isAvailable) {
+      throw new Error('AI is not available');
+    }
+
+    // Create a new session if necessary
+    if (!this.#session) {
+      await this.createSession();
+    }
+
+    // Start timing the AI
+    const start = Date.now();
+    console.info('Prompting AI...');
+
+    // Prompt the AI with a timeout
+    const timeout = this.#isRunningTest ? 10 : 15000;
+    let result: string | false = false;
+    try {
+      result = await Promise.race([
+        // Prompt the AI
+        this.#session!.prompt(prompt),
+        // Wait for 15 seconds before timing out
+        sleep(timeout).then(() => false as const)
+      ]);
+    } catch (error) {
+      // If an error ocurred during the prompt, destroy the session
+      this.#session!.destroy();
+      this.#session = undefined;
+
+      // Re-throw the error to be handled by the caller
+      throw error;
+    }
+
+    // Throw an error if the AI took too long to respond
+    if (!result) {
+      throw new Error('AI took too long to respond');
+    }
+
+    // Log the duration the AI took to respond
+    const duration = Date.now() - start;
+    console.info(`AI took ${duration}ms to respond`);
+
+    return result.trim();
+  }
+
+  /**
+   * Generate a palette fitting the given hex color using the local AI.
+   */
+  public async generatePalette(hex: string): Promise<Palette> {
+    // Check if the AI is available
+    if (!this.isAvailable) {
+      throw new Error('AI is not available');
+    }
+
+    // Create the base color and palette
+    const shade = new Shade(-1, Value.fromHEX(hex), true);
+    const primary = new Color([shade], 'Primary');
+
+    const aiPalette = new Palette('AI (experimental)', []);
+    aiPalette.addColor(primary);
+
+    /*
+     * Retry up to 3 times if generation does not succeed.
+     * This is necessary because the AI can sometimes take too long to
+     * respond, respond in an unexpected format or not respond at all.
+     */
+    // Prompt the AI for a color palette
+    for (let tries = 0; tries < 3; tries++) {
+      try {
+        // Use a random scheme to prime the AI
+        const scheme = randomScheme().label.split('.')[1];
+        console.info(`Generating a ${scheme} color palette...`);
+
+        // Prompt the AI for a color palette
+        let response = await this.prompt(
+          `Generate a ${scheme} color palette with 3 to 7 colors using this as a starting point: "${hex}".
+          Please return a JSON array of colors with the following format: \`[{hex: string, name: string}, nextColor, ...]\`.
+          Always response in pure json string format that matches the JSON schema above, not markdown or other format!!`
+        );
+
+        // Remove markdown code block if present
+        if (response.startsWith('```json')) {
+          response = response.replaceAll('```json', '').replaceAll('```', '').trim();
+        }
+
+        // Attempt to parse the response as a JSON array of colors with hex and name properties
+        let colors;
+        try {
+          colors = JSON.parse(response);
+        } catch (error) {
+          console.error(error, response);
+          continue;
+        }
+        if (!Array.isArray(colors)) {
+          if ('colors' in colors && Array.isArray(colors.colors)) {
+            colors = colors.colors;
+          } else {
+            console.warn('Invalid response:', response);
+            continue;
+          }
+        }
+
+        // Loop through the generated colors and add them to the palette
+        for (const color of colors) {
+          // Check if the color is valid (has a hex property)
+          if (typeof color !== 'object' || !color.hex) {
+            console.warn('Invalid color:', color);
+            continue;
+          }
+
+          // Skip the color if it is the same as the base color
+          if (color.hex === hex) {
+            if (color.name) {
+              primary.name = color.name;
+            }
+            continue;
+          }
+
+          // Create a shade and color from the generated hex code and add it to the palette
+          const shade = new Shade(-1, Value.fromHEX(color.hex), true);
+          const name = color.name || (await this.#colorNameService.getColorName(shade));
+          aiPalette.addColor(new Color([shade], name));
+        }
+
+        // If the AI successfully generated at least one color, return the palette
+        if (aiPalette.colors.length > 1) {
+          return aiPalette;
+        }
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } catch (error: any) {
+        // If the AI took too long to respond, warn and continue, otherwise log the error
+        if (error.message === 'AI took too long to respond') {
+          console.warn('AI took too long to respond');
+          continue;
+        } else {
+          console.error(error);
+          break;
+        }
+      }
+    }
+
+    // If the AI failed to generate a palette, throw an error
+    throw new Error('AI failed to generate a palette');
+  }
+}
+
+export class AiServiceMock {
+  public readonly isAvailable = false;
+
+  public async prompt(_prompt: string): Promise<string> {
+    return '';
+  }
+
+  public async generatePalette(hex: string): Promise<Palette> {
+    return new Palette('AI (experimental)', [new Color([new Shade(-1, Value.fromHEX(hex), true)], 'Primary')]);
+  }
+}

--- a/src/app/shared/data-access/analytics.service.ts
+++ b/src/app/shared/data-access/analytics.service.ts
@@ -260,6 +260,9 @@ export class AnalyticsService {
       case PaletteScheme.SURPRISE:
         name = TrackingEventName.GENERATE_PALETTE_SURPRISE;
         break;
+      case PaletteScheme.AI:
+        name = TrackingEventName.GENERATE_PALETTE_AI;
+        break;
       case PaletteScheme.MONOCHROME:
         name = TrackingEventName.GENERATE_PALETTE_MONOCHROME;
         break;

--- a/src/app/shared/data-access/palette.service.spec.ts
+++ b/src/app/shared/data-access/palette.service.spec.ts
@@ -3,6 +3,7 @@ import { PaletteScheme } from '../constants/palette-scheme';
 import { TailwindGrays } from '../constants/tailwind-colors';
 import { LocalStorageKey } from '../enums/local-storage-keys';
 import { Palette, Shade } from '../model';
+import { AiService, AiServiceMock } from './ai.service';
 import { ColorNameService, ColorNameServiceMock } from './color-name.service';
 import { ColorService, ColorServiceMock } from './color.service';
 import { ListService, ListServiceMock } from './list.service';
@@ -33,6 +34,10 @@ describe('PaletteService', () => {
         {
           provide: ListService,
           useValue: listService
+        },
+        {
+          provide: AiService,
+          useClass: AiServiceMock
         }
       ]
     });

--- a/src/app/shared/enums/tracking-event.ts
+++ b/src/app/shared/enums/tracking-event.ts
@@ -110,6 +110,10 @@ export enum TrackingEventName {
    */
   EXPORT_PALETTE_UNKNOWN = 'EXPORT_PALETTE_UNKNOWN',
   /**
+   * User generates a palette with the AI.
+   */
+  GENERATE_PALETTE_AI = 'GENERATE_PALETTE_AI',
+  /**
    * User generates an analogous palette.
    */
   GENERATE_PALETTE_ANALOGOUS = 'GENERATE_PALETTE_ANALOGOUS',

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -244,6 +244,7 @@
     "update-success": "Rainbow Palette wurde erfolgreich auf Version {{ version }} aktualisiert. Viel Spaß mit den neuen Funktionen!"
   },
   "scheme": {
+    "ai": "KI generiert (experimentell)",
     "analogous": "Analog",
     "complementary": "Komplementär",
     "compound": "Zusammengesetzt",
@@ -262,11 +263,13 @@
   "toast": {
     "error": {
       "copy-clipboard": "Beim Kopieren in die Zwischenablage ist ein Fehler aufgetreten. Stelle sicher, dass du diese Webseite über HTTPS aufrufst.",
+      "generate-ai-palette": "Beim Generieren der Palette mit KI ist ein Fehler aufgetreten.\n\nDies ist ein experimentelles Feature und funktioniert möglicherweise nicht wie geplant. Versuche es erneut oder verwende ein anderes Schema.",
       "load-color-map": "Die Liste mit Namen für Farben konnte nicht geladen werden.",
       "palette-load": "Deine letzte Farbpalette konnte nicht geladen werden."
     },
     "info": {
-      "analytics-accepted": "Vielen Dank, dass du mir hilfst, die Seite zu verbessern."
+      "analytics-accepted": "Vielen Dank, dass du mir hilfst, die Seite zu verbessern.",
+      "generate-ai-palette": "Deine lokale KI im Browser wurde aufgefordert, eine Palette für dich zu generieren. Dies ist aktuell noch experimentell und kann ein paar Sekunden dauern."
     }
   },
   "view": {

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -245,6 +245,7 @@
     "update-success": "Rainbow Palette has been updated to version {{ version }}. Enjoy the new features!"
   },
   "scheme": {
+    "ai": "AI generated (experimental)",
     "analogous": "Analogous",
     "complementary": "Complementary",
     "compound": "Compound",
@@ -263,11 +264,13 @@
   "toast": {
     "error": {
       "copy-clipboard": "An error occurred while copying to your clipboard. Please make sure you are visiting this site via HTTPS.",
+      "generate-ai-palette": "An error occurred while generating the AI palette.\n\nThis is an experimental feature and may not work as expected. Try again or use another scheme.",
       "load-color-map": "An error occurred while loading the list of color names.",
       "palette-load": "An error occurred while loading your last palette."
     },
     "info": {
-      "analytics-accepted": "Thank you for helping me improve the site."
+      "analytics-accepted": "Thank you for helping me improve the site.",
+      "generate-ai-palette": "Your local AI in the browser was prompted to generate a palette for you. This is experimental and can take a few seconds."
     }
   },
   "view": {

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,0 +1,81 @@
+/**
+ * Flags for whether a Chrome AI session is available.
+ */
+export type ChromeAISessionAvailable = 'no' | 'readily';
+
+/**
+ * Options for creating a new AI session.
+ */
+export interface ChromeAISessionOptions {
+  /**
+   * Temperature of the model.
+   * Higher temperature means the model will take more risks.
+   *
+   * Must be a number between 0 and 1.
+   */
+  temperature: number;
+  topK: number;
+}
+
+/**
+ * A Chrome AI session.
+ */
+export interface ChromeAISession {
+  /**
+   * Destroys the session.
+   */
+  destroy: () => Promise<void>;
+  /**
+   * Prompts the model with a given prompt and returns the model's response.
+   */
+  prompt: (prompt: string) => Promise<string>;
+  /**
+   * Prompts the model with a given prompt and streams the model's response.
+   */
+  promptStreaming: (prompt: string) => ReadableStream<string>;
+  /**
+   * Executes the model with a given prompt and returns the model's response.
+   */
+  execute: (prompt: string) => Promise<string>;
+  /**
+   * Executes the model with a given prompt and streams the model's response.
+   */
+  executeStreaming: (prompt: string) => ReadableStream<string>;
+}
+
+/**
+ * The Chrome AI prompt API.
+ */
+export interface ChromePromptAPI {
+  /**
+   * Checks if a generic AI session can be created.
+   */
+  canCreateGenericSession: () => Promise<ChromeAISessionAvailable>;
+  /**
+   * Checks if a text AI session can be created.
+   */
+  canCreateTextSession: () => Promise<ChromeAISessionAvailable>;
+  /**
+   * Gets the default options for a generic AI session.
+   */
+  defaultGenericSessionOptions: () => Promise<ChromeAISessionOptions>;
+  /**
+   * Gets the default options for a text AI session.
+   */
+  defaultTextSessionOptions: () => Promise<ChromeAISessionOptions>;
+  /**
+   * Creates a new generic AI session.
+   */
+  createGenericSession: (options?: ChromeAISessionOptions) => Promise<ChromeAISession>;
+  /**
+   * Creates a new text AI session.
+   */
+  createTextSession: (options?: ChromeAISessionOptions) => Promise<ChromeAISession>;
+}
+
+declare global {
+  // eslint-disable-next-line no-var
+  var ai: ChromePromptAPI | undefined;
+  // eslint-disable-next-line no-var
+  var model = ai;
+}

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,7 +1,27 @@
 /**
+ * Copy of the Chrome AI package types:
+ * https://github.com/jeasonstudio/chrome-ai
+ */
+
+/**
  * Flags for whether a Chrome AI session is available.
  */
-export type ChromeAISessionAvailable = 'no' | 'readily';
+export type ChromeAISessionAvailable = 'no' | 'after-download' | 'readily';
+
+/**
+ * Information about the AI model.
+ */
+export interface ChromeAIModelInfo {
+  /**
+   * Default temperature of the model.
+   * Higher temperature means the model will take more risks.
+   *
+   * Must be a number between 0 and 1.
+   */
+  defaultTemperature: number;
+  defaultTopK: number;
+  maxTopK: number;
+}
 
 /**
  * Options for creating a new AI session.
@@ -13,8 +33,8 @@ export interface ChromeAISessionOptions {
    *
    * Must be a number between 0 and 1.
    */
-  temperature: number;
-  topK: number;
+  temperature?: number;
+  topK?: number;
 }
 
 /**
@@ -33,14 +53,6 @@ export interface ChromeAISession {
    * Prompts the model with a given prompt and streams the model's response.
    */
   promptStreaming: (prompt: string) => ReadableStream<string>;
-  /**
-   * Executes the model with a given prompt and returns the model's response.
-   */
-  execute: (prompt: string) => Promise<string>;
-  /**
-   * Executes the model with a given prompt and streams the model's response.
-   */
-  executeStreaming: (prompt: string) => ReadableStream<string>;
 }
 
 /**
@@ -50,27 +62,33 @@ export interface ChromePromptAPI {
   /**
    * Checks if a generic AI session can be created.
    */
-  canCreateGenericSession: () => Promise<ChromeAISessionAvailable>;
-  /**
-   * Checks if a text AI session can be created.
-   */
   canCreateTextSession: () => Promise<ChromeAISessionAvailable>;
   /**
-   * Gets the default options for a generic AI session.
+   * Gets information about the text model.
    */
-  defaultGenericSessionOptions: () => Promise<ChromeAISessionOptions>;
-  /**
-   * Gets the default options for a text AI session.
-   */
-  defaultTextSessionOptions: () => Promise<ChromeAISessionOptions>;
-  /**
-   * Creates a new generic AI session.
-   */
-  createGenericSession: (options?: ChromeAISessionOptions) => Promise<ChromeAISession>;
+  textModelInfo: () => Promise<ChromeAIModelInfo>;
   /**
    * Creates a new text AI session.
    */
   createTextSession: (options?: ChromeAISessionOptions) => Promise<ChromeAISession>;
+}
+
+/**
+ * Options for the Chrome AI polyfill.
+ */
+export interface PolyfillChromeAIOptions {
+  /**
+   * Path to the model asset.
+   */
+  modelAssetPath: string;
+  /**
+   * Path to the model metadata.
+   */
+  wasmLoaderPath: string;
+  /**
+   * Path to the model binary.
+   */
+  wasmBinaryPath: string;
 }
 
 declare global {
@@ -78,4 +96,6 @@ declare global {
   var ai: ChromePromptAPI | undefined;
   // eslint-disable-next-line no-var
   var model = ai;
+  // eslint-disable-next-line no-var
+  var __polyfill_ai_options__: Partial<PolyfillChromeAIOptions> | undefined;
 }


### PR DESCRIPTION
## General information
This uses the experimental local Gemini Nano model embedded into Google Chrome to generate a palette. The proof of concept was already done in ab76818.

When the local AI is not enabled or not available this feature will not be visible to the user.

## Changes
- Add "AI generated" palette scheme
- Add `AiService` to interact with the model and generate a palette
- Add basic tests for `AiService`
  - If the model is not available the tests are expecting errors to be thrown
  - If the model is available the tests are expecting timeout errors since the timeout is set so low the model has no chance to answer. These tests are mainly so that the API still works, not complete feature tests