### PR TITLE
Custom dialogs

### DIFF
--- a/src/app/editor/data-access/color-editor.service.ts
+++ b/src/app/editor/data-access/color-editor.service.ts
@@ -25,7 +25,8 @@ export class ColorEditorService {
         shadeIndex
       },
       disableClose: true,
-      panelClass: 'rp-modal-panel'
+      panelClass: 'rp-modal-panel',
+      width: 'inherit'
     });
 
     return await firstValueFrom(dialogRef.closed.pipe(tap(() => this._isModalOpen.set(false))));

--- a/src/app/editor/editor.component.html
+++ b/src/app/editor/editor.component.html
@@ -76,7 +76,7 @@
       [disabled]="!hasUnsavedChanges()"
       [title]="'editor.save' | translate"
       (click)="save()"
-      class="cursor-pointer rounded bg-blue-500 px-2 py-1.5 font-semibold text-neutral-50 disabled:cursor-wait disabled:bg-neutral-400 dark:bg-blue-600 dark:disabled:bg-neutral-700"
+      class="cursor-pointer rounded bg-blue-500 px-2 py-1.5 font-semibold text-neutral-50 disabled:cursor-not-allowed disabled:bg-neutral-400 dark:bg-blue-600 dark:disabled:bg-neutral-700"
     >
       {{ 'common.save' | translate }}
     </button>

--- a/src/app/export/data-access/export-modal.service.ts
+++ b/src/app/export/data-access/export-modal.service.ts
@@ -23,7 +23,8 @@ export class ExportModalService {
       data: {
         palette
       },
-      panelClass: 'rp-modal-panel'
+      panelClass: 'rp-modal-panel',
+      width: 'inherit'
     });
 
     return await firstValueFrom(dialogRef.closed.pipe(tap(() => this._isModalOpen.set(false))));

--- a/src/app/export/export-modal.component.html
+++ b/src/app/export/export-modal.component.html
@@ -27,7 +27,7 @@
       />
 
       <span class="sr-only">
-        {{ 'common.back' | translate }}
+        {{ 'common.close' | translate }}
       </span>
     </button>
   </div>

--- a/src/app/list/list.component.ts
+++ b/src/app/list/list.component.ts
@@ -31,11 +31,13 @@ export default class ListComponent {
   protected readonly heroPlusMini = heroPlusMini;
 
   protected async deletePalette(palette: PaletteListItem): Promise<void> {
-    const shouldDelete = await this._dialogService.confirm(
-      this._translateService.instant('list.delete.dialog', {
+    const shouldDelete = await this._dialogService.confirm({
+      title: 'list.delete.hover',
+      message: this._translateService.instant('list.delete.dialog', {
         name: palette.name
-      })
-    );
+      }),
+      confirmLabel: 'common.delete'
+    });
     if (shouldDelete) {
       this._listService.remove(palette.id);
     }

--- a/src/app/shared/data-access/dialog.service.spec.ts
+++ b/src/app/shared/data-access/dialog.service.spec.ts
@@ -25,7 +25,7 @@ describe('DialogService', () => {
 
   it('should confirm', async () => {
     // Setup dialog for confirm test
-    const dialog = new DialogMock(undefined);
+    const dialog = new DialogMock(true);
 
     TestBed.configureTestingModule({
       providers: [{ provide: Dialog, useValue: dialog }]
@@ -34,12 +34,15 @@ describe('DialogService', () => {
 
     // Test
     spyOn(dialog, 'open').and.callThrough();
-    spyOn(window, 'confirm').and.returnValue(true);
 
-    const result = await service.confirm('message');
+    const result = await service.confirm({
+      title: 'title',
+      message: 'message',
+      confirmLabel: 'confirm'
+    });
 
+    expect(dialog.open).toHaveBeenCalledTimes(1);
     expect(result).toBeTrue();
-    expect(window.confirm).toHaveBeenCalledWith('message');
   });
 
   it('should alert', async () => {

--- a/src/app/shared/data-access/dialog.service.spec.ts
+++ b/src/app/shared/data-access/dialog.service.spec.ts
@@ -1,19 +1,20 @@
+import { Dialog } from '@angular/cdk/dialog';
 import { TestBed } from '@angular/core/testing';
+import { DialogMock } from '../utils/dialog-mock';
 import { DialogService } from './dialog.service';
 
 describe('DialogService', () => {
-  let service: DialogService;
-
-  beforeEach(() => {
-    TestBed.configureTestingModule({});
-    service = TestBed.inject(DialogService);
-  });
-
-  it('should be created', () => {
-    expect(service).toBeTruthy();
-  });
-
   it('should prompt', async () => {
+    // Setup dialog for prompt test
+    const dialog = new DialogMock(undefined);
+
+    TestBed.configureTestingModule({
+      providers: [{ provide: Dialog, useValue: dialog }]
+    });
+    const service = TestBed.inject(DialogService);
+
+    // Test
+    spyOn(dialog, 'open').and.callThrough();
     spyOn(window, 'prompt').and.returnValue('Test');
 
     const result = await service.prompt('message', 'default');
@@ -23,6 +24,16 @@ describe('DialogService', () => {
   });
 
   it('should confirm', async () => {
+    // Setup dialog for confirm test
+    const dialog = new DialogMock(undefined);
+
+    TestBed.configureTestingModule({
+      providers: [{ provide: Dialog, useValue: dialog }]
+    });
+    const service = TestBed.inject(DialogService);
+
+    // Test
+    spyOn(dialog, 'open').and.callThrough();
     spyOn(window, 'confirm').and.returnValue(true);
 
     const result = await service.confirm('message');
@@ -32,10 +43,23 @@ describe('DialogService', () => {
   });
 
   it('should alert', async () => {
-    spyOn(window, 'alert');
+    // Setup dialog for alert test
+    const dialog = new DialogMock<void>(undefined);
 
-    await service.alert('message');
+    TestBed.configureTestingModule({
+      providers: [{ provide: Dialog, useValue: dialog }]
+    });
+    const service = TestBed.inject(DialogService);
 
-    expect(window.alert).toHaveBeenCalledWith('message');
+    // Test
+    spyOn(dialog, 'open').and.callThrough();
+
+    const result = await service.alert({
+      title: 'title',
+      message: 'message'
+    });
+
+    expect(dialog.open).toHaveBeenCalledTimes(1);
+    expect(result).toBeUndefined();
   });
 });

--- a/src/app/shared/data-access/dialog.service.spec.ts
+++ b/src/app/shared/data-access/dialog.service.spec.ts
@@ -6,7 +6,7 @@ import { DialogService } from './dialog.service';
 describe('DialogService', () => {
   it('should prompt', async () => {
     // Setup dialog for prompt test
-    const dialog = new DialogMock(undefined);
+    const dialog = new DialogMock('Test');
 
     TestBed.configureTestingModule({
       providers: [{ provide: Dialog, useValue: dialog }]
@@ -15,12 +15,16 @@ describe('DialogService', () => {
 
     // Test
     spyOn(dialog, 'open').and.callThrough();
-    spyOn(window, 'prompt').and.returnValue('Test');
 
-    const result = await service.prompt('message', 'default');
+    const result = await service.prompt({
+      title: 'title',
+      message: 'message',
+      confirmLabel: 'confirm',
+      initialValue: 'initial'
+    });
 
+    expect(dialog.open).toHaveBeenCalledTimes(1);
     expect(result).toBe('Test');
-    expect(window.prompt).toHaveBeenCalledWith('message', 'default');
   });
 
   it('should confirm', async () => {

--- a/src/app/shared/data-access/dialog.service.ts
+++ b/src/app/shared/data-access/dialog.service.ts
@@ -1,7 +1,7 @@
 import { Dialog } from '@angular/cdk/dialog';
 import { inject, Injectable } from '@angular/core';
-import { firstValueFrom } from 'rxjs';
-import { AlertConfig } from '../types/dialog-config';
+import { firstValueFrom, map } from 'rxjs';
+import { AlertConfig, ConfirmConfig } from '../types/dialog-config';
 
 @Injectable({
   providedIn: 'root'
@@ -13,8 +13,18 @@ export class DialogService {
     return window.prompt(message, defaultValue) ?? undefined;
   }
 
-  public async confirm(message: string): Promise<boolean> {
-    return window.confirm(message);
+  public async confirm(config: Omit<ConfirmConfig, 'type'>): Promise<boolean> {
+    const confirmComponent = await import('../ui/dialog/dialog.component').then((c) => c.DialogComponent);
+    const dialogRef = this._dialog.open<boolean>(confirmComponent, {
+      backdropClass: 'rp-modal-backdrop',
+      data: {
+        ...config,
+        type: 'confirm'
+      },
+      panelClass: 'rp-modal-panel'
+    });
+
+    return await firstValueFrom(dialogRef.closed.pipe(map((result) => !!result)));
   }
 
   public async alert(config: Omit<AlertConfig, 'type'>): Promise<void> {
@@ -37,7 +47,7 @@ export class DialogServiceMock {
     return `${value}_test`;
   }
 
-  public async confirm(_: string): Promise<boolean> {
+  public async confirm(_config: Omit<ConfirmConfig, 'type'>): Promise<boolean> {
     return true;
   }
 

--- a/src/app/shared/data-access/dialog.service.ts
+++ b/src/app/shared/data-access/dialog.service.ts
@@ -1,9 +1,14 @@
-import { Injectable } from '@angular/core';
+import { Dialog } from '@angular/cdk/dialog';
+import { inject, Injectable } from '@angular/core';
+import { firstValueFrom } from 'rxjs';
+import { AlertConfig } from '../types/dialog-config';
 
 @Injectable({
   providedIn: 'root'
 })
 export class DialogService {
+  private readonly _dialog = inject(Dialog);
+
   public async prompt(message: string, defaultValue: string): Promise<string | undefined> {
     return window.prompt(message, defaultValue) ?? undefined;
   }
@@ -12,8 +17,18 @@ export class DialogService {
     return window.confirm(message);
   }
 
-  public async alert(message: string): Promise<void> {
-    window.alert(message);
+  public async alert(config: Omit<AlertConfig, 'type'>): Promise<void> {
+    const alertComponent = await import('../ui/dialog/dialog.component').then((c) => c.DialogComponent);
+    const dialogRef = this._dialog.open<void>(alertComponent, {
+      backdropClass: 'rp-modal-backdrop',
+      data: {
+        ...config,
+        type: 'alert'
+      },
+      panelClass: 'rp-modal-panel'
+    });
+
+    return await firstValueFrom(dialogRef.closed);
   }
 }
 
@@ -26,7 +41,7 @@ export class DialogServiceMock {
     return true;
   }
 
-  public async alert(_: string): Promise<void> {
+  public async alert(_config: Omit<AlertConfig, 'type'>): Promise<void> {
     return;
   }
 }

--- a/src/app/shared/data-access/dialog.service.ts
+++ b/src/app/shared/data-access/dialog.service.ts
@@ -17,7 +17,8 @@ export class DialogService {
         ...config,
         type: 'prompt'
       },
-      panelClass: 'rp-modal-panel'
+      panelClass: 'rp-modal-panel',
+      width: 'inherit'
     });
 
     return await firstValueFrom(dialogRef.closed.pipe(map((result) => result ?? undefined)));
@@ -31,7 +32,8 @@ export class DialogService {
         ...config,
         type: 'confirm'
       },
-      panelClass: 'rp-modal-panel'
+      panelClass: 'rp-modal-panel',
+      width: 'inherit'
     });
 
     return await firstValueFrom(dialogRef.closed.pipe(map((result) => !!result)));
@@ -45,7 +47,8 @@ export class DialogService {
         ...config,
         type: 'alert'
       },
-      panelClass: 'rp-modal-panel'
+      panelClass: 'rp-modal-panel',
+      width: 'inherit'
     });
 
     return await firstValueFrom(dialogRef.closed);

--- a/src/app/shared/data-access/pwa.service.ts
+++ b/src/app/shared/data-access/pwa.service.ts
@@ -105,15 +105,17 @@ export class PwaService {
     }
 
     // Update was downloaded and can be installed through restart
-    const restart = await this._dialogService.confirm(
-      this._translateService.instant('pwa.restart', {
+    const restart = await this._dialogService.confirm({
+      title: 'pwa.update',
+      message: this._translateService.instant('pwa.restart', {
         old:
           // @ts-expect-error - `appData` is filled by the prebuilt script to contain the current app version
           event.currentVersion.appData?.version ?? this._versionService.appVersion,
         // @ts-expect-error - `appData` is filled by the prebuilt script to contain the current app version
         new: event.latestVersion.appData?.version
-      })
-    );
+      }),
+      confirmLabel: 'common.yes'
+    });
 
     // Continue without updating
     if (!restart) {

--- a/src/app/shared/data-access/pwa.service.ts
+++ b/src/app/shared/data-access/pwa.service.ts
@@ -56,7 +56,7 @@ export class PwaService {
 
     // Listen for broken service worker
     this._SwUpdate.unrecoverable.subscribe(() => {
-      this._dialogService.alert(this._translateService.instant('pwa.broken'));
+      this._dialogService.alert({ title: 'common.error', message: 'pwa.broken' });
     });
 
     // Check if the app is currently updating

--- a/src/app/shared/types/dialog-config.ts
+++ b/src/app/shared/types/dialog-config.ts
@@ -1,0 +1,24 @@
+export type AlertConfig = {
+  type: 'alert';
+  title: string;
+  message: string;
+};
+
+export type ConfirmConfig = {
+  type: 'confirm';
+  title: string;
+  message: string;
+  confirmLabel: string;
+};
+
+export type PromptConfig = {
+  type: 'prompt';
+  title: string;
+  message: string;
+  confirmLabel: string;
+  label?: string;
+  placeholder?: string;
+  initialValue?: string;
+};
+
+export type DialogConfig = AlertConfig | ConfirmConfig | PromptConfig;

--- a/src/app/shared/ui/dialog/dialog.component.html
+++ b/src/app/shared/ui/dialog/dialog.component.html
@@ -1,0 +1,56 @@
+@let configuration = config();
+
+<article
+  class="mx-auto flex w-full max-w-lg flex-col gap-4 rounded bg-neutral-100 p-4 shadow-md dark:border dark:border-neutral-600 dark:bg-neutral-700 dark:shadow-none"
+>
+  <section>
+    <h1 class="text-xl font-semibold">
+      {{ title() | translate }}
+    </h1>
+
+    <p>
+      {{ message() | translate }}
+    </p>
+  </section>
+
+  @if (configuration.type === 'prompt') {
+    <section>
+      @if (configuration.label) {
+        <label
+          class="block font-semibold"
+          for="dialog-input"
+        >
+          {{ configuration.label | translate }}
+        </label>
+      }
+
+      <input
+        [formControl]="input"
+        [placeholder]="configuration.placeholder ?? ''"
+        class="w-full min-w-0 grow rounded-md border-transparent bg-neutral-200 px-4 py-2 invalid:border-red-600 focus:outline-none focus:ring-0 dark:bg-neutral-600"
+        id="dialog-input"
+        type="text"
+      />
+    </section>
+  }
+
+  <section class="flex justify-end gap-2">
+    @if (type() !== 'alert') {
+      <button
+        [title]="'editor.cancel' | translate"
+        (click)="dismiss()"
+        class="cursor-pointer rounded bg-neutral-300 px-2 py-1.5 font-semibold dark:bg-neutral-600"
+      >
+        {{ 'common.cancel' | translate }}
+      </button>
+    }
+
+    <button
+      [title]="confirmLabel() | translate"
+      (click)="confirm()"
+      class="cursor-pointer rounded bg-blue-500 px-2 py-1.5 font-semibold text-neutral-50 disabled:cursor-wait disabled:bg-neutral-400 dark:bg-blue-600 dark:disabled:bg-neutral-700"
+    >
+      {{ confirmLabel() | translate }}
+    </button>
+  </section>
+</article>

--- a/src/app/shared/ui/dialog/dialog.component.html
+++ b/src/app/shared/ui/dialog/dialog.component.html
@@ -3,11 +3,11 @@
 >
   <section>
     <h1 class="text-xl font-semibold">
-      {{ config.title| translate }}
+      {{ config.title | translate }}
     </h1>
 
     <p>
-      {{ config.message| translate }}
+      {{ config.message | translate }}
     </p>
   </section>
 
@@ -24,7 +24,7 @@
 
       <input
         [formControl]="input"
-        [placeholder]="config.placeholder ?? ''"
+        [placeholder]="config.placeholder ?? '' | translate"
         class="w-full min-w-0 grow rounded-md border-transparent bg-neutral-200 px-4 py-2 invalid:border-red-600 focus:outline-none focus:ring-0 dark:bg-neutral-600"
         id="dialog-input"
         type="text"
@@ -35,7 +35,7 @@
   <section class="flex justify-end gap-2">
     @if (config.type !== 'alert') {
       <button
-        [title]="'editor.cancel' | translate"
+        [title]="'common.cancel' | translate"
         (click)="dismiss()"
         class="cursor-pointer rounded bg-neutral-300 px-2 py-1.5 font-semibold dark:bg-neutral-600"
       >
@@ -44,9 +44,10 @@
     }
 
     <button
+      [disabled]="config.type === 'prompt' && input.invalid"
       [title]="confirmLabel | translate"
       (click)="confirm()"
-      class="cursor-pointer rounded bg-blue-500 px-2 py-1.5 font-semibold text-neutral-50 disabled:cursor-wait disabled:bg-neutral-400 dark:bg-blue-600 dark:disabled:bg-neutral-700"
+      class="cursor-pointer rounded bg-blue-500 px-2 py-1.5 font-semibold text-neutral-50 disabled:cursor-not-allowed disabled:bg-neutral-400 dark:bg-blue-600 dark:disabled:bg-neutral-700"
     >
       {{ confirmLabel | translate }}
     </button>

--- a/src/app/shared/ui/dialog/dialog.component.html
+++ b/src/app/shared/ui/dialog/dialog.component.html
@@ -1,32 +1,30 @@
-@let configuration = config();
-
 <article
   class="mx-auto flex w-full max-w-lg flex-col gap-4 rounded bg-neutral-100 p-4 shadow-md dark:border dark:border-neutral-600 dark:bg-neutral-700 dark:shadow-none"
 >
   <section>
     <h1 class="text-xl font-semibold">
-      {{ title() | translate }}
+      {{ config.title| translate }}
     </h1>
 
     <p>
-      {{ message() | translate }}
+      {{ config.message| translate }}
     </p>
   </section>
 
-  @if (configuration.type === 'prompt') {
+  @if (config.type === 'prompt') {
     <section>
-      @if (configuration.label) {
+      @if (config.label) {
         <label
           class="block font-semibold"
           for="dialog-input"
         >
-          {{ configuration.label | translate }}
+          {{ config.label | translate }}
         </label>
       }
 
       <input
         [formControl]="input"
-        [placeholder]="configuration.placeholder ?? ''"
+        [placeholder]="config.placeholder ?? ''"
         class="w-full min-w-0 grow rounded-md border-transparent bg-neutral-200 px-4 py-2 invalid:border-red-600 focus:outline-none focus:ring-0 dark:bg-neutral-600"
         id="dialog-input"
         type="text"
@@ -35,7 +33,7 @@
   }
 
   <section class="flex justify-end gap-2">
-    @if (type() !== 'alert') {
+    @if (config.type !== 'alert') {
       <button
         [title]="'editor.cancel' | translate"
         (click)="dismiss()"
@@ -46,11 +44,11 @@
     }
 
     <button
-      [title]="confirmLabel() | translate"
+      [title]="confirmLabel | translate"
       (click)="confirm()"
       class="cursor-pointer rounded bg-blue-500 px-2 py-1.5 font-semibold text-neutral-50 disabled:cursor-wait disabled:bg-neutral-400 dark:bg-blue-600 dark:disabled:bg-neutral-700"
     >
-      {{ confirmLabel() | translate }}
+      {{ confirmLabel | translate }}
     </button>
   </section>
 </article>

--- a/src/app/shared/ui/dialog/dialog.component.spec.ts
+++ b/src/app/shared/ui/dialog/dialog.component.spec.ts
@@ -1,22 +1,189 @@
+import { DIALOG_DATA, DialogRef } from '@angular/cdk/dialog';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { TranslateModule } from '@ngx-translate/core';
+import { AlertConfig, ConfirmConfig, PromptConfig } from '../../types/dialog-config';
 import { DialogComponent } from './dialog.component';
 
 describe('DialogComponent', () => {
   let component: DialogComponent;
   let fixture: ComponentFixture<DialogComponent>;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [DialogComponent]
-    })
-    .compileComponents();
+  describe('Alert', () => {
+    let dialogRef: {
+      close: () => void;
+    };
 
-    fixture = TestBed.createComponent(DialogComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
+    const config: AlertConfig = {
+      type: 'alert',
+      title: 'Alert',
+      message: 'This is an alert message.'
+    };
+
+    beforeEach(async () => {
+      dialogRef = {
+        close: (): void => {}
+      };
+
+      await TestBed.configureTestingModule({
+        imports: [DialogComponent, TranslateModule.forRoot()],
+        providers: [
+          {
+            provide: DIALOG_DATA,
+            useValue: config
+          },
+          {
+            provide: DialogRef,
+            useValue: dialogRef
+          }
+        ]
+      }).compileComponents();
+
+      fixture = TestBed.createComponent(DialogComponent);
+      component = fixture.componentInstance;
+      fixture.detectChanges();
+    });
+
+    it('should create', () => {
+      expect(component).toBeTruthy();
+    });
+
+    it('should dismiss and confirm', () => {
+      spyOn(dialogRef, 'close');
+
+      component.dismiss();
+      expect(dialogRef.close).toHaveBeenCalledTimes(1);
+
+      component.confirm();
+      expect(dialogRef.close).toHaveBeenCalledTimes(2);
+    });
   });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
+  describe('Confirm', () => {
+    let dialogRef: { close: (result?: boolean) => void };
+
+    const config: ConfirmConfig = {
+      type: 'confirm',
+      title: 'Alert',
+      message: 'This is an alert message.',
+      confirmLabel: 'Yes'
+    };
+
+    beforeEach(async () => {
+      dialogRef = {
+        close: (_result?: boolean): void => {}
+      };
+
+      await TestBed.configureTestingModule({
+        imports: [DialogComponent, TranslateModule.forRoot()],
+        providers: [
+          {
+            provide: DIALOG_DATA,
+            useValue: config
+          },
+          {
+            provide: DialogRef,
+            useValue: dialogRef
+          }
+        ]
+      }).compileComponents();
+
+      fixture = TestBed.createComponent(DialogComponent);
+      component = fixture.componentInstance;
+      fixture.detectChanges();
+    });
+
+    it('should create', () => {
+      expect(component).toBeTruthy();
+    });
+
+    it('should dismiss', () => {
+      spyOn(dialogRef, 'close');
+
+      component.dismiss();
+      expect(dialogRef.close).toHaveBeenCalledWith();
+    });
+
+    it('should confirm', () => {
+      spyOn(dialogRef, 'close');
+
+      component.confirm();
+      expect(dialogRef.close).toHaveBeenCalledWith(true);
+    });
+  });
+
+  describe('Prompt', () => {
+    let dialogRef: { close: (result?: string) => void };
+
+    const config: PromptConfig = {
+      type: 'prompt',
+      title: 'Alert',
+      message: 'This is an alert message.',
+      confirmLabel: 'Yes',
+      initialValue: 'Test',
+      label: 'Input',
+      placeholder: 'Placeholder'
+    };
+
+    beforeEach(async () => {
+      dialogRef = {
+        close: (_result?: string): void => {}
+      };
+
+      await TestBed.configureTestingModule({
+        imports: [DialogComponent, TranslateModule.forRoot()],
+        providers: [
+          {
+            provide: DIALOG_DATA,
+            useValue: config
+          },
+          {
+            provide: DialogRef,
+            useValue: dialogRef
+          }
+        ]
+      }).compileComponents();
+
+      fixture = TestBed.createComponent(DialogComponent);
+      component = fixture.componentInstance;
+      fixture.detectChanges();
+    });
+
+    it('should create', () => {
+      expect(component).toBeTruthy();
+    });
+
+    it('should dismiss', () => {
+      spyOn(dialogRef, 'close');
+
+      component.dismiss();
+      expect(dialogRef.close).toHaveBeenCalledWith();
+    });
+
+    it('should dismiss when unchanged', () => {
+      spyOn(dialogRef, 'close');
+
+      component.confirm();
+      expect(dialogRef.close).toHaveBeenCalledWith();
+    });
+
+    it('should not close when invalid', () => {
+      spyOn(dialogRef, 'close');
+
+      // @ts-expect-error - Input is protected
+      component.input.setValue('');
+
+      component.confirm();
+      expect(dialogRef.close).toHaveBeenCalledTimes(0);
+    });
+
+    it('should confirm after change', () => {
+      spyOn(dialogRef, 'close');
+
+      // @ts-expect-error - Input is protected
+      component.input.setValue('Test2');
+
+      component.confirm();
+      expect(dialogRef.close).toHaveBeenCalledWith('Test2');
+    });
   });
 });

--- a/src/app/shared/ui/dialog/dialog.component.spec.ts
+++ b/src/app/shared/ui/dialog/dialog.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { DialogComponent } from './dialog.component';
+
+describe('DialogComponent', () => {
+  let component: DialogComponent;
+  let fixture: ComponentFixture<DialogComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [DialogComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(DialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/shared/ui/dialog/dialog.component.stories.ts
+++ b/src/app/shared/ui/dialog/dialog.component.stories.ts
@@ -1,0 +1,46 @@
+import { Meta } from '@storybook/angular';
+import { createStory } from '../../utils/storybook';
+import { DialogComponent } from './dialog.component';
+
+const meta: Meta<DialogComponent> = {
+  title: 'Shared/Dialog',
+  component: DialogComponent,
+  tags: ['autodocs'],
+  argTypes: {}
+};
+export default meta;
+
+export const Alert = createStory<DialogComponent>({
+  args: {
+    config: {
+      type: 'alert',
+      title: 'Alert',
+      message: 'This is an alert message.'
+    }
+  }
+});
+
+export const Confirm = createStory<DialogComponent>({
+  args: {
+    config: {
+      type: 'confirm',
+      title: 'Confirm',
+      message: 'This is a confirm message.',
+      confirmLabel: 'Yes'
+    }
+  }
+});
+
+export const Prompt = createStory<DialogComponent>({
+  args: {
+    config: {
+      type: 'prompt',
+      title: 'Prompt',
+      message: 'This is a prompt message.',
+      confirmLabel: 'Save',
+      label: 'Name',
+      placeholder: 'Enter your name',
+      initialValue: 'John Doe'
+    }
+  }
+});

--- a/src/app/shared/ui/dialog/dialog.component.stories.ts
+++ b/src/app/shared/ui/dialog/dialog.component.stories.ts
@@ -1,4 +1,5 @@
-import { Meta } from '@storybook/angular';
+import { DIALOG_DATA } from '@angular/cdk/dialog';
+import { applicationConfig, Meta } from '@storybook/angular';
 import { createStory } from '../../utils/storybook';
 import { DialogComponent } from './dialog.component';
 
@@ -11,36 +12,57 @@ const meta: Meta<DialogComponent> = {
 export default meta;
 
 export const Alert = createStory<DialogComponent>({
-  args: {
-    config: {
-      type: 'alert',
-      title: 'Alert',
-      message: 'This is an alert message.'
-    }
-  }
+  decorators: [
+    applicationConfig({
+      providers: [
+        {
+          provide: DIALOG_DATA,
+          useValue: {
+            type: 'alert',
+            title: 'Alert',
+            message: 'This is an alert message.'
+          }
+        }
+      ]
+    })
+  ]
 });
 
 export const Confirm = createStory<DialogComponent>({
-  args: {
-    config: {
-      type: 'confirm',
-      title: 'Confirm',
-      message: 'This is a confirm message.',
-      confirmLabel: 'Yes'
-    }
-  }
+  decorators: [
+    applicationConfig({
+      providers: [
+        {
+          provide: DIALOG_DATA,
+          useValue: {
+            type: 'confirm',
+            title: 'Confirm',
+            message: 'This is a confirm message.',
+            confirmLabel: 'Yes'
+          }
+        }
+      ]
+    })
+  ]
 });
 
 export const Prompt = createStory<DialogComponent>({
-  args: {
-    config: {
-      type: 'prompt',
-      title: 'Prompt',
-      message: 'This is a prompt message.',
-      confirmLabel: 'Save',
-      label: 'Name',
-      placeholder: 'Enter your name',
-      initialValue: 'John Doe'
-    }
-  }
+  decorators: [
+    applicationConfig({
+      providers: [
+        {
+          provide: DIALOG_DATA,
+          useValue: {
+            type: 'prompt',
+            title: 'Prompt',
+            message: 'This is a prompt message.',
+            confirmLabel: 'Save',
+            label: 'Name',
+            placeholder: 'Enter your name',
+            initialValue: 'John Doe'
+          }
+        }
+      ]
+    })
+  ]
 });

--- a/src/app/shared/ui/dialog/dialog.component.stories.ts
+++ b/src/app/shared/ui/dialog/dialog.component.stories.ts
@@ -1,7 +1,11 @@
-import { DIALOG_DATA } from '@angular/cdk/dialog';
-import { applicationConfig, Meta } from '@storybook/angular';
+import { DIALOG_DATA, DialogRef } from '@angular/cdk/dialog';
+import { Meta, applicationConfig } from '@storybook/angular';
 import { createStory } from '../../utils/storybook';
 import { DialogComponent } from './dialog.component';
+
+const dialogRef = {
+  close: (): void => {}
+};
 
 const meta: Meta<DialogComponent> = {
   title: 'Shared/Dialog',
@@ -22,6 +26,10 @@ export const Alert = createStory<DialogComponent>({
             title: 'Alert',
             message: 'This is an alert message.'
           }
+        },
+        {
+          provide: DialogRef,
+          useValue: dialogRef
         }
       ]
     })
@@ -40,6 +48,10 @@ export const Confirm = createStory<DialogComponent>({
             message: 'This is a confirm message.',
             confirmLabel: 'Yes'
           }
+        },
+        {
+          provide: DialogRef,
+          useValue: dialogRef
         }
       ]
     })
@@ -61,6 +73,10 @@ export const Prompt = createStory<DialogComponent>({
             placeholder: 'Enter your name',
             initialValue: 'John Doe'
           }
+        },
+        {
+          provide: DialogRef,
+          useValue: dialogRef
         }
       ]
     })

--- a/src/app/shared/ui/dialog/dialog.component.ts
+++ b/src/app/shared/ui/dialog/dialog.component.ts
@@ -1,0 +1,44 @@
+import { ChangeDetectionStrategy, Component, computed, effect, input } from '@angular/core';
+import { FormControl, ReactiveFormsModule, Validators } from '@angular/forms';
+import { TranslateModule } from '@ngx-translate/core';
+import { DialogConfig } from '../../types/dialog-config';
+
+@Component({
+  selector: 'rp-dialog',
+  standalone: true,
+  imports: [TranslateModule, ReactiveFormsModule],
+  templateUrl: './dialog.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class DialogComponent {
+  public readonly config = input.required<DialogConfig>();
+
+  protected readonly type = computed(() => this.config().type);
+  protected readonly title = computed(() => this.config().title);
+  protected readonly message = computed(() => this.config().message);
+  protected readonly confirmLabel = computed(() => {
+    const config = this.config();
+    if (config.type === 'alert') {
+      return 'common.ok';
+    }
+
+    return config.confirmLabel;
+  });
+
+  protected readonly input = new FormControl('', {
+    nonNullable: true,
+    validators: [Validators.required]
+  });
+
+  public constructor() {
+    effect(() => {
+      const config = this.config();
+      if (config.type === 'prompt') {
+        this.input.setValue(config.initialValue ?? '');
+      }
+    });
+  }
+
+  protected dismiss(): void {}
+  protected confirm(): void {}
+}

--- a/src/app/view/utils/unsaved-changes.guard.ts
+++ b/src/app/view/utils/unsaved-changes.guard.ts
@@ -1,6 +1,5 @@
 import { Signal, inject } from '@angular/core';
 import { CanDeactivateFn } from '@angular/router';
-import { TranslateService } from '@ngx-translate/core';
 import { DialogService } from '../../shared/data-access/dialog.service';
 
 export interface UnsavedChangesComponent {
@@ -13,8 +12,11 @@ export const unsavedChangesGuard: CanDeactivateFn<UnsavedChangesComponent> = asy
   }
 
   const dialogService = inject(DialogService);
-  const translateService = inject(TranslateService);
-  const leave = await dialogService.confirm(translateService.instant('view.unsaved-changes'));
+  const leave = await dialogService.confirm({
+    title: 'view.unsaved-changes.title',
+    message: 'view.unsaved-changes.description',
+    confirmLabel: 'common.continue'
+  });
 
   return leave;
 };

--- a/src/app/view/view.component.ts
+++ b/src/app/view/view.component.ts
@@ -182,11 +182,13 @@ export default class ViewComponent implements OnInit, UnsavedChangesComponent {
 
   public async removeColor(color: Color): Promise<void> {
     const name = color.name;
-    const shouldRemove = await this._dialogService.confirm(
-      this._translateService.instant('view.color.remove', {
+    const shouldRemove = await this._dialogService.confirm({
+      title: 'view.color.remove-tooltip',
+      message: this._translateService.instant('view.color.remove', {
         color: name
-      })
-    );
+      }),
+      confirmLabel: 'common.remove'
+    });
 
     if (shouldRemove) {
       this.palette()?.removeColor(color);

--- a/src/app/view/view.component.ts
+++ b/src/app/view/view.component.ts
@@ -94,10 +94,14 @@ export default class ViewComponent implements OnInit, UnsavedChangesComponent {
       return;
     }
 
-    const newName = await this._dialogService.prompt(
-      this._translateService.instant('view.palette.rename'),
-      palette.name
-    );
+    const newName = await this._dialogService.prompt({
+      title: 'common.rename',
+      message: 'view.palette.rename',
+      confirmLabel: 'common.rename',
+      initialValue: palette.name,
+      label: 'common.name',
+      placeholder: 'common.name'
+    });
 
     if (!newName || newName === palette.name) {
       return;
@@ -151,7 +155,14 @@ export default class ViewComponent implements OnInit, UnsavedChangesComponent {
   }
 
   public async renameColor(color: Color): Promise<void> {
-    const newName = await this._dialogService.prompt(this._translateService.instant('view.color.rename'), color.name);
+    const newName = await this._dialogService.prompt({
+      title: 'common.rename',
+      message: 'view.color.rename',
+      confirmLabel: 'common.rename',
+      initialValue: color.name,
+      label: 'common.name',
+      placeholder: 'common.name'
+    });
 
     if (!newName || newName === color.name) {
       return;

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -6,6 +6,7 @@
     "delete": "Löschen",
     "duplicate": "Duplizieren",
     "edit": "Bearbeiten",
+    "error": "Unerwarteter Fehler",
     "export": "Exportieren",
     "hue": "Farbton",
     "less": "Weniger anzeigen",

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -11,6 +11,7 @@
     "less": "Weniger anzeigen",
     "lightness": "Helligkeit",
     "more": "Mehr anzeigen",
+    "ok": "OK",
     "rename": "Umbenennen",
     "saturation": "Sättigung",
     "save": "Speichern",

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -13,6 +13,7 @@
     "less": "Weniger anzeigen",
     "lightness": "Helligkeit",
     "more": "Mehr anzeigen",
+    "name": "Name",
     "ok": "OK",
     "remove": "Entfernen",
     "rename": "Umbenennen",

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -3,6 +3,7 @@
     "back": "Zurück",
     "cancel": "Abbrechen",
     "close": "Schließen",
+    "continue": "Fortfahren",
     "delete": "Löschen",
     "duplicate": "Duplizieren",
     "edit": "Bearbeiten",
@@ -13,10 +14,12 @@
     "lightness": "Helligkeit",
     "more": "Mehr anzeigen",
     "ok": "OK",
+    "remove": "Entfernen",
     "rename": "Umbenennen",
     "saturation": "Sättigung",
     "save": "Speichern",
-    "saving": "Speichern..."
+    "saving": "Speichern...",
+    "yes": "Ja"
   },
   "editor": {
     "cancel": "Ohne speichern schließen",
@@ -241,6 +244,7 @@
   "pwa": {
     "broken": "Es scheint, als ob deine aktuelle Version von Rainbow Palette nicht richtig funktioniert. Die App wird neu geladen, um das Problem zu beheben.",
     "restart": "Eine neue Version von Rainbow Palette ist verfügbar. Willst du jetzt von Version {{ old }} auf Version {{ new }} upgraden?\n\nDeine aktuelle Palette inklusive Änderungen wird nach dem Upgrade wiederhergestellt.",
+    "update": "Update verfügbar",
     "update-available": "Version {{ version }} ist verfügbar! Wird heruntergeladen...",
     "update-failed": "Update auf Version {{ version }} ist fehlgeschlagen. Bitte versuche es später erneut.",
     "update-success": "Rainbow Palette wurde erfolgreich auf Version {{ version }} aktualisiert. Viel Spaß mit den neuen Funktionen!"
@@ -278,7 +282,7 @@
       "add-tooltip": "Füge deiner Palette eine neue Farbe hinzu",
       "click": "Click, um die Schattierung anzupassen\nRechtsclick, um den Hex-Code zu kopieren",
       "copy": "\"{{ color }}\" wurde in deine Zwischenablage kopiert.",
-      "remove": "Bust du sicher, dass du die Farbe \"{{ color }}\" entfernen möchtest?",
+      "remove": "Bist du sicher, dass du die Farbe \"{{ color }}\" entfernen möchtest?",
       "remove-tooltip": "Entferne diese Farbe aus deiner Palette",
       "removed": "Die Farbe \"{{ color }}\" wurde entfernt.",
       "rename": "Gebe deiner Farbe einen neuen Namen",
@@ -293,6 +297,9 @@
       "saved": "Deine Palette wurde lokal gespeichert.",
       "saving": "Deine Palette wird im Browser gespeichert"
     },
-    "unsaved-changes": "Die Änderungen an deiner Palette wurden noch nicht gespeichert. Wenn du die Seite verlässt, gehen alle Änderungen verloren.\n\nBist du sicher, dass du die Seite verlassen möchtest?"
+    "unsaved-changes": {
+      "description": "Die Änderungen an deiner Palette wurden noch nicht gespeichert. Wenn du die Seite verlässt, gehen alle Änderungen verloren.\n\nBist du sicher, dass du die Seite verlassen möchtest?",
+      "title": "Ungespeicherte Änderungen"
+    }
   }
 }

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -11,6 +11,7 @@
     "less": "Show less",
     "lightness": "Lightness",
     "more": "Show more",
+    "ok": "OK",
     "rename": "Rename",
     "saturation": "Saturation",
     "save": "Save",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -13,6 +13,7 @@
     "less": "Show less",
     "lightness": "Lightness",
     "more": "Show more",
+    "name": "Name",
     "ok": "OK",
     "remove": "Remove",
     "rename": "Rename",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -6,6 +6,7 @@
     "delete": "Delete",
     "duplicate": "Duplicate",
     "edit": "Edit",
+    "error": "Unexpected error",
     "export": "Export",
     "hue": "Hue",
     "less": "Show less",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -3,6 +3,7 @@
     "back": "Back",
     "cancel": "Cancel",
     "close": "Close",
+    "continue": "Continue",
     "delete": "Delete",
     "duplicate": "Duplicate",
     "edit": "Edit",
@@ -13,10 +14,12 @@
     "lightness": "Lightness",
     "more": "Show more",
     "ok": "OK",
+    "remove": "Remove",
     "rename": "Rename",
     "saturation": "Saturation",
     "save": "Save",
-    "saving": "Saving..."
+    "saving": "Saving...",
+    "yes": "Yes"
   },
   "editor": {
     "cancel": "Close editor without saving",
@@ -242,6 +245,7 @@
   "pwa": {
     "broken": "Unfortunately your current version of Rainbow Palette is not working properly. The app will be reloaded to fix this issue.",
     "restart": "A new version of Rainbow Palette is available. Do you want to reload the app now to upgrade from version {{ old }} to version {{ new }}?\n\nYour current palette and changes will be restored after the update.",
+    "update": "Update available",
     "update-available": "Version {{ version }} is available. Downloading...",
     "update-failed": "Update to version {{ version }} failed. Please try again later.",
     "update-success": "Rainbow Palette has been updated to version {{ version }}. Enjoy the new features!"
@@ -294,6 +298,9 @@
       "saved": "Your palette has been saved.",
       "saving": "Saving your palette in your browser"
     },
-    "unsaved-changes": "You have unsaved changes in your palette. If you leave this page, your changes will be lost.\n\nAre you sure you want to leave?"
+    "unsaved-changes": {
+      "description": "You have unsaved changes in your palette. If you leave this page, your changes will be lost.\n\nAre you sure you want to leave?",
+      "title": "Unsaved changes"
+    }
   }
 }


### PR DESCRIPTION
## Changes
- Add a custom dialog component to show instead of using the browsers APIs
- Open all dialogs with their intended width instead of using the content width
- Fix some translations

## New Dialog 💬 

![Dialogs](https://github.com/user-attachments/assets/12872876-eee1-4996-8eac-a04b92c61f00)

This is what I originally wanted to do in:
- #39 
- #40