### PR TITLE
Rename duplicates of palettes

### DIFF
--- a/src/app/list/list.component.ts
+++ b/src/app/list/list.component.ts
@@ -47,9 +47,23 @@ export default class ListComponent {
     // Load the palette to duplicate
     this._paletteService.loadPaletteFromLocalStorage(palette.id);
 
+    const name = await this._dialogService.prompt({
+      title: 'list.duplicate.hover',
+      message: this._translateService.instant('list.duplicate.dialog', {
+        name: palette.name
+      }),
+      confirmLabel: 'common.duplicate',
+      label: 'common.name',
+      placeholder: 'common.name'
+    });
+
+    if (!name) {
+      return;
+    }
+
     try {
       // Create a copy of the palette and open it
-      const copyId = this._paletteService.duplicatePalette();
+      const copyId = this._paletteService.duplicatePalette(name);
       await this._router.navigate(['/view', copyId], {
         info: {
           palette: 'new'

--- a/src/app/shared/data-access/palette.service.spec.ts
+++ b/src/app/shared/data-access/palette.service.spec.ts
@@ -100,10 +100,11 @@ describe('PaletteService', () => {
     await service.generatePalette('#ffffff', PaletteScheme.ANALOGOUS);
     const originalPalette = service.palette();
 
-    const id = service.duplicatePalette();
+    const id = service.duplicatePalette('duplicate');
 
     expect(id).toBeTruthy();
     expect(id).not.toBe(originalPalette!.id);
+    expect(service.palette()?.name).toBe('duplicate');
     expect(service.palette()?.id).toBe(id);
   });
 

--- a/src/app/shared/data-access/palette.service.ts
+++ b/src/app/shared/data-access/palette.service.ts
@@ -93,7 +93,7 @@ export class PaletteService {
     }
   }
 
-  public duplicatePalette(): string {
+  public duplicatePalette(name?: string): string {
     const palette = this._palette();
     if (!palette) {
       throw new Error('No palette to duplicate');
@@ -101,7 +101,11 @@ export class PaletteService {
 
     // Copy palette with new id and name
     const copy = palette.copy(false);
-    copy.name = `${copy.name} (copy)`;
+    if (name) {
+      copy.name = name;
+    } else {
+      copy.name = `${copy.name} (copy)`;
+    }
 
     // Load the copy
     this._palette.set(copy);

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -220,7 +220,10 @@
       "dialog": "Bist du sicher, dass du die Palette \"{{ name }}\" löschen möchtest?\n\nDie Palette kann nicht wiederhergestellt werden.",
       "hover": "Palette löschen"
     },
-    "duplicate": "Palette duplizieren",
+    "duplicate": {
+      "dialog": "Wie möchtest du die Kopie von \"{{ name }}\" nennen?",
+      "hover": "Palette duplizieren"
+    },
     "new": "Neue Palette",
     "title": "Deine Farbpaletten",
     "view": "Palette \"{{ name }}\" ansehen"

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -221,7 +221,10 @@
       "dialog": "Are you sure you want to delete the palette \"{{ name }}\"?\n\nThis action cannot be undone.",
       "hover": "Delete palette"
     },
-    "duplicate": "Duplicate palette",
+    "duplicate": {
+      "dialog": "What should the duplicate of the palette \"{{ name }}\" be called?",
+      "hover": "Duplicate palette"
+    },
     "new": "New palette",
     "title": "Your palettes",
     "view": "View palette \"{{ name }}\""


### PR DESCRIPTION
### Changes
- Allow custom name for duplicate palettes
- Open prompt to enter a new name when duplicating a palette

### Issues
- #72 

### Depends on
- #71